### PR TITLE
disable "unsafe" scipy in WHITELISTED_LIBRARIES

### DIFF
--- a/pandasai/constants.py
+++ b/pandasai/constants.py
@@ -84,6 +84,6 @@ WHITELISTED_LIBRARIES = [
     "json",
     "io",
     "base64",
-    "scipy",
+    # "scipy",
     "streamlit",
 ]


### PR DESCRIPTION
Found exploit that leverages a flaw in the SciPy library, utilizing the imported ctypes module to execute arbitrary code.

PoC: https://github.com/tangledgroup/pandasai-sandbox-exploit/blob/2bdd4d7ebaea9c0d1633ee9cbccc256e1b5a2b33/exploit.py#L65