### PR TITLE
fix: set Agent.last_code_executed correctly

### DIFF
--- a/pandasai/agent/callbacks.py
+++ b/pandasai/agent/callbacks.py
@@ -30,7 +30,9 @@ class Callbacks:
         Args:
             code (str): A python code
         """
-        self.agent.last_code_executed = code
+        self.agent.last_code_executed = self.agent.chat_pipeline.context.get(
+            "last_code_executed"
+        )
 
     def on_result(self, result):
         """

--- a/pandasai/pipelines/chat/code_execution.py
+++ b/pandasai/pipelines/chat/code_execution.py
@@ -100,6 +100,8 @@ class CodeExecution(BaseLogicUnit):
                     code_to_run, self.context, self.logger, e
                 )
 
+        self.context.add("last_code_executed", code_manager.last_code_executed)
+
         return LogicUnitOutput(
             result,
             True,

--- a/pandasai/pipelines/chat/code_execution.py
+++ b/pandasai/pipelines/chat/code_execution.py
@@ -24,7 +24,7 @@ class CodeExecution(BaseLogicUnit):
         on_retry: Callable[[str, Exception], None] = None,
         **kwargs,
     ):
-        super().__init__()
+        super().__init__(**kwargs)
         self.on_failure = on_failure
         self.on_retry = on_retry
 

--- a/pandasai/pipelines/chat/generate_chat_pipeline.py
+++ b/pandasai/pipelines/chat/generate_chat_pipeline.py
@@ -62,7 +62,7 @@ class GenerateChatPipeline:
                 ),
                 CachePopulation(skip_if=self.is_cached),
                 CodeExecution(
-                    before_execution=on_code_execution,
+                    on_execution=on_code_execution,
                     on_failure=self.on_code_execution_failure,
                     on_retry=self.on_code_retry,
                 ),

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from typing import Optional
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pandas as pd
 import pytest
@@ -352,21 +352,15 @@ How much has the total salary expense increased?
         assert isinstance(llm, LangchainLLM)
         assert llm.langchain_llm == langchain_llm
 
-    @patch.object(
-        CodeManager,
-        "execute_code",
-        return_value={
-            "type": "string",
-            "value": "There are 10 countries in the dataframe.",
-        },
+    @patch(
+        "pandasai.pipelines.chat.code_execution.CodeManager.last_code_executed",
+        new_callable=PropertyMock,
     )
-    def test_last_code_executed(self, _mocked_method, agent: Agent):
-        expected_result = {
-            "type": "string",
-            "value": "There are 10 countries in the dataframe.",
-        }
+    def test_last_code_executed(self, _mocked_property, agent: Agent):
+        expected_code = "result = {'type': 'string', 'value': 'There are 10 countries in the dataframe.'}"
+        _mocked_property.return_value = expected_code
         agent.chat("How many countries are in the dataframe?")
-        assert agent.last_code_executed == expected_result
+        assert agent.last_code_executed == expected_code
 
     @patch.object(
         CodeManager,

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -360,6 +360,22 @@ How much has the total salary expense increased?
             "value": "There are 10 countries in the dataframe.",
         },
     )
+    def test_last_code_executed(self, _mocked_method, agent: Agent):
+        expected_result = {
+            "type": "string",
+            "value": "There are 10 countries in the dataframe.",
+        }
+        agent.chat("How many countries are in the dataframe?")
+        assert agent.last_code_executed == expected_result
+
+    @patch.object(
+        CodeManager,
+        "execute_code",
+        return_value={
+            "type": "string",
+            "value": "There are 10 countries in the dataframe.",
+        },
+    )
     def test_last_result_is_saved(self, _mocked_method, agent: Agent):
         assert agent.last_result is None
 


### PR DESCRIPTION
- [x] Fixes an issue where pipeline runs were not calling the `on_code_execution` callback, and so `Agent.last_code_executed` was not updated.
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).