### PR TITLE
fix: add attribute check to avoid "AttributeError: 'Call' object has no attribute 'id'

### DIFF
--- a/pandasai/helpers/code_manager.py
+++ b/pandasai/helpers/code_manager.py
@@ -394,6 +394,7 @@ Code running:
         return (
             isinstance(value, ast.Call)
             and isinstance(value.func, ast.Attribute)
+            and hasattr(value.func.value, "id")
             and value.func.value.id == "pd"
             and value.func.attr == "DataFrame"
         )


### PR DESCRIPTION
Add attribute check to avoid "AttributeError: 'Call' object has no attribute 'id' or "AttributeError: 'Subscript' object has no attribute 'id'"
