### PR TITLE
fix: set Agent.last_code_executed correctly

### DIFF
--- a/pandasai/agent/callbacks.py
+++ b/pandasai/agent/callbacks.py
@@ -30,7 +30,7 @@ class Callbacks:
         Args:
             code (str): A python code
         """
-        self.agent.last_code_executed = code
+        self.agent.last_code_executed = self.agent.context.get("last_code_executed")
 
     def on_result(self, result):
         """

--- a/pandasai/pipelines/chat/code_execution.py
+++ b/pandasai/pipelines/chat/code_execution.py
@@ -100,6 +100,8 @@ class CodeExecution(BaseLogicUnit):
                     code_to_run, self.context, self.logger, e
                 )
 
+        self.context.add("last_code_executed", code_manager.last_code_executed)
+
         return LogicUnitOutput(
             result,
             True,

--- a/pandasai/pipelines/chat/generate_chat_pipeline.py
+++ b/pandasai/pipelines/chat/generate_chat_pipeline.py
@@ -74,7 +74,7 @@ class GenerateChatPipeline:
             query_exec_tracker=self.query_exec_tracker,
             steps=[
                 CodeExecution(
-                    before_execution=on_code_execution,
+                    on_execution=on_code_execution,
                     on_failure=self.on_code_execution_failure,
                     on_retry=self.on_code_retry,
                 ),

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from typing import Optional
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pandas as pd
 import pytest
@@ -405,6 +405,16 @@ How much has the total salary expense increased?
         llm = agent.get_llm(langchain_llm)
         assert isinstance(llm, LangchainLLM)
         assert llm.langchain_llm == langchain_llm
+
+    @patch(
+        "pandasai.pipelines.chat.code_execution.CodeManager.last_code_executed",
+        new_callable=PropertyMock,
+    )
+    def test_last_code_executed(self, _mocked_property, agent: Agent):
+        expected_code = "result = {'type': 'string', 'value': 'There are 10 countries in the dataframe.'}"
+        _mocked_property.return_value = expected_code
+        agent.chat("How many countries are in the dataframe?")
+        assert agent.last_code_executed == expected_code
 
     @patch.object(
         CodeManager,


### PR DESCRIPTION
- [x] Fixes an issue where pipeline runs were not calling the `on_code_execution` callback, and so `Agent.last_code_executed` was not updated.
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

Repeat of #992 (can't be reopened) and targets the same issue as #1007 .