### PR TITLE
fix: access value.func.value.id after checking AST node

### DIFF
--- a/pandasai/helpers/code_manager.py
+++ b/pandasai/helpers/code_manager.py
@@ -394,6 +394,7 @@ Code running:
         return (
             isinstance(value, ast.Call)
             and isinstance(value.func, ast.Attribute)
+            and isinstance(value.func.value, ast.Name)
             and value.func.value.id == "pd"
             and value.func.attr == "DataFrame"
         )

--- a/tests/unit_tests/test_codemanager.py
+++ b/tests/unit_tests/test_codemanager.py
@@ -225,6 +225,14 @@ print(os.listdir())
         with pytest.raises(BadImportError):
             code_manager.execute_code(malicious_code, exec_context)
 
+    def test_clean_code_accesses_node_id(
+        self, code_manager: CodeManager, exec_context: MagicMock
+    ):
+        """Test that value.func.value.id is accessed safely in _check_is_df_declaration."""
+        pandas_code = """unique_countries = dfs[0]['country'].unique()
+smallest_countries = df.sort_values(by='area').head()"""
+        assert code_manager._clean_code(pandas_code, exec_context) == pandas_code
+
     def test_remove_dfs_overwrites(
         self, code_manager: CodeManager, exec_context: MagicMock
     ):


### PR DESCRIPTION
- [x] Closes #1014 .
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

Targets the same issue as #1013 , but adds a test to cover where `value.func.value` has type `ast.Subscript` or `ast.Call`, instead of type `ast.Name` as expected.