### PR TITLE
fix: wrap LangChain LLMs correctly

### DIFF
--- a/pandasai/agent/base.py
+++ b/pandasai/agent/base.py
@@ -141,7 +141,7 @@ class Agent:
 
         config = load_config_from_json(config)
 
-        if isinstance(config, dict) and config.get("llm") is None:
+        if isinstance(config, dict) and config.get("llm") is not None:
             config["llm"] = self.get_llm(config["llm"])
 
         config = Config(**config)

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -402,9 +402,9 @@ How much has the total salary expense increased?
     def test_load_llm_with_langchain_llm(self, agent: Agent, llm):
         langchain_llm = OpenAI(openai_api_key="fake_key")
 
-        llm = agent.get_llm(langchain_llm)
-        assert isinstance(llm, LangchainLLM)
-        assert llm.langchain_llm == langchain_llm
+        config = agent.get_config({"llm": langchain_llm})
+        assert isinstance(config.llm, LangchainLLM)
+        assert config.llm.langchain_llm == langchain_llm
 
     @patch(
         "pandasai.pipelines.chat.code_execution.CodeManager.last_code_executed",


### PR DESCRIPTION
- [x] Fixes an issue where `Agent.get_llm` was not called to wrap LangChain LLMs.
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).