### PR TITLE
feat(llm): support local LLMs compatible with OpenAI API

### DIFF
--- a/pandasai/helpers/memory.py
+++ b/pandasai/helpers/memory.py
@@ -79,6 +79,25 @@ class Memory:
                 messages.append({"role": "assistant", "message": message["message"]})
         return messages
 
+    def to_openai_messages(self):
+        """
+        Returns the conversation messages in the format expected by the OpenAI API
+        """
+        messages = []
+        if self.agent_info:
+            messages.append(
+                {
+                    "role": "system",
+                    "content": self.get_system_prompt(),
+                }
+            )
+        for message in self.all():
+            if message["is_user"]:
+                messages.append({"role": "user", "content": message["message"]})
+            else:
+                messages.append({"role": "assistant", "content": message["message"]})
+        return messages
+
     def clear(self):
         self._messages = []
 

--- a/pandasai/llm/base.py
+++ b/pandasai/llm/base.py
@@ -338,23 +338,7 @@ class BaseOpenAI(LLM):
             str: LLM response.
 
         """
-        messages = []
-        if memory:
-            if memory.agent_info:
-                messages.append(
-                    {
-                        "role": "system",
-                        "content": memory.get_system_prompt(),
-                    }
-                )
-
-            for message in memory.all():
-                if message["is_user"]:
-                    messages.append({"role": "user", "content": message["message"]})
-                else:
-                    messages.append(
-                        {"role": "assistant", "content": message["message"]}
-                    )
+        messages = memory.to_openai_messages() if memory else []
 
         # adding current prompt as latest query message
         messages.append(

--- a/pandasai/llm/local_llm.py
+++ b/pandasai/llm/local_llm.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from openai import OpenAI
+
+from ..helpers.memory import Memory
+from ..prompts.base import BasePrompt
+from .base import LLM
+
+if TYPE_CHECKING:
+    from pandasai.pipelines.pipeline_context import PipelineContext
+
+
+class LocalLLM(LLM):
+    def __init__(self, api_base: str, model: str, **kwargs):
+        self.api_base = api_base
+        self.model = model
+        self.client = OpenAI(base_url=api_base, api_key="ignored").chat.completions
+        self._invocation_params = kwargs
+
+    def chat_completion(self, value: str, memory: Memory) -> str:
+        messages = memory.to_openai_messages() if memory else []
+
+        # adding current prompt as latest query message
+        messages.append(
+            {
+                "role": "user",
+                "content": value,
+            }
+        )
+
+        params = {"model": self.model, "messages": messages, **self._invocation_params}
+        response = self.client.create(**params)
+
+        return response.choices[0].message.content
+
+    def call(self, instruction: BasePrompt, context: PipelineContext = None) -> str:
+        self.last_prompt = instruction.to_string()
+
+        memory = context.memory if context else None
+
+        return self.chat_completion(self.last_prompt, memory)
+
+    @property
+    def type(self) -> str:
+        return "local"

--- a/tests/unit_tests/llms/test_local_llm.py
+++ b/tests/unit_tests/llms/test_local_llm.py
@@ -53,7 +53,7 @@ class TestLocalLLM:
         mock_create.assert_called_once()
 
     def test_chat_completion_with_memory(self, local_llm, client):
-        expected_text = "This is the generated text with memory."
+        expected_text = "This is the generated text."
         memory = Memory()
         memory.add("Previous user message", True)
         memory.add("Previous assistant message", False)
@@ -72,7 +72,7 @@ class TestLocalLLM:
         assert len(kwargs["messages"]) == 3
 
     def test_call_method(self, local_llm, client, prompt):
-        expected_text = "This is the generated text from call."
+        expected_text = "This is the generated text."
         mock_response = MagicMock(
             choices=[MagicMock(message=MagicMock(content=expected_text))]
         )

--- a/tests/unit_tests/llms/test_local_llm.py
+++ b/tests/unit_tests/llms/test_local_llm.py
@@ -1,0 +1,84 @@
+"""Unit tests for the local LLM class"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pandasai.helpers.memory import Memory
+from pandasai.llm.local_llm import LocalLLM
+from pandasai.prompts import BasePrompt
+
+
+@pytest.fixture
+def client():
+    with patch("pandasai.llm.local_llm.OpenAI") as client:
+        mock_completions = MagicMock()
+        mock_response = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="Mocked response"))]
+        )
+        mock_completions.create.return_value = mock_response
+        client.return_value.chat.completions = mock_completions
+        yield client
+
+
+@pytest.fixture
+def local_llm(client):
+    return LocalLLM(api_base="http://localhost:1234/v1", model="bamboo-llm")
+
+
+@pytest.fixture
+def prompt():
+    class MockBasePrompt(BasePrompt):
+        template: str = "Hello"
+
+    return MockBasePrompt()
+
+
+class TestLocalLLM:
+    """Unit tests for the local LLM class"""
+
+    def test_local_llm_type(self, local_llm):
+        assert local_llm.type == "local"
+
+    def test_chat_completion_no_memory(self, local_llm, client):
+        expected_text = "This is the generated text."
+        mock_response = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=expected_text))]
+        )
+        mock_create = client.return_value.chat.completions.create
+        mock_create.return_value = mock_response
+
+        result = local_llm.chat_completion("Hello", None)
+        assert result == expected_text
+        mock_create.assert_called_once()
+
+    def test_chat_completion_with_memory(self, local_llm, client):
+        expected_text = "This is the generated text with memory."
+        memory = Memory()
+        memory.add("Previous user message", True)
+        memory.add("Previous assistant message", False)
+        mock_response = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=expected_text))]
+        )
+        mock_create = client.return_value.chat.completions.create
+        mock_create.return_value = mock_response
+
+        result = local_llm.chat_completion("Hello", memory)
+        assert result == expected_text
+        mock_create.assert_called_once()
+
+        _, kwargs = mock_create.call_args
+        assert "messages" in kwargs
+        assert len(kwargs["messages"]) == 3
+
+    def test_call_method(self, local_llm, client, prompt):
+        expected_text = "This is the generated text from call."
+        mock_response = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=expected_text))]
+        )
+        mock_create = client.return_value.chat.completions.create
+        mock_create.return_value = mock_response
+
+        result = local_llm.call(instruction=prompt)
+        assert result == expected_text
+        mock_create.assert_called_once()


### PR DESCRIPTION
- [x] Closes #155 , #187 , #341 , #799 , #996 .
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

Similar to [CrewAI's approach](https://docs.crewai.com/how-to/LLM-Connections/#openai-compatible-api-endpoints) to supporting local LLMs.

# Usage

```python
from pandasai.llm.local_llm import LocalLLM
```

## Ollama

Ollama's compatibility is experimental (see [docs](https://github.com/ollama/ollama/blob/main/docs/openai.md)).

```python
llm = LocalLLM(model="ollama-model", api_base="http://localhost:11434/v1")
```

## LM Studio

```python
llm = LocalLLM(model="", api_base="http://localhost:1234/v1")
```