### PR TITLE
fix: sqlite connector override base equals

### DIFF
--- a/pandasai/connectors/sql.py
+++ b/pandasai/connectors/sql.py
@@ -539,6 +539,21 @@ class SqliteConnector(SQLConnector):
             f"table={self.config.table}>"
         )
 
+    def equals(self, other):
+        if isinstance(other, self.__class__):
+            print(self.config.database)
+            print(other.config.database)
+            return (
+                self.config.dialect,
+                self.config.driver,
+                self.config.database,
+            ) == (
+                other.config.dialect,
+                other.config.driver,
+                other.config.database,
+            )
+        return False
+
 
 class MySQLConnector(SQLConnector):
     """

--- a/tests/unit_tests/connectors/test_sqlite.py
+++ b/tests/unit_tests/connectors/test_sqlite.py
@@ -83,3 +83,29 @@ class TestSqliteConnector(unittest.TestCase):
         # Test fallback_name property
         fallback_name = self.connector.fallback_name
         self.assertEqual(fallback_name, "yourtable")
+
+    @patch("pandasai.connectors.SqliteConnector._init_connection")
+    def test_two_connector_equal(self, mock_init_connection):
+        conn1 = SqliteConnector(self.config)
+
+        conn2 = SqliteConnector(self.config)
+
+        assert conn1.equals(conn2)
+
+        config2 = SqliteConnectorConfig(
+            dialect="sqlite", database="path_todb.db", table="different_table"
+        ).dict()
+        conn3 = SqliteConnector(config2)
+
+        assert conn1.equals(conn3)
+
+    @patch("pandasai.connectors.SqliteConnector._init_connection")
+    def test_two_connector_not_equal(self, mock_init_connection):
+        conn1 = SqliteConnector(self.config)
+
+        config2 = SqliteConnectorConfig(
+            dialect="sqlite", database="path_todb2.db", table="yourtable"
+        ).dict()
+        conn3 = SqliteConnector(config2)
+
+        assert not conn1.equals(conn3)


### PR DESCRIPTION
function for sqlite connector

Closes #1067 
