### PR TITLE
docs: revert changes in pandas imports

### DIFF
--- a/docs/LLMs/llms.md
+++ b/docs/LLMs/llms.md
@@ -81,7 +81,7 @@ You can count the number of tokens used by a prompt as follows:
 from pandasai import SmartDataframe
 from pandasai.llm import OpenAI
 from pandasai.helpers.openai_info import get_openai_callback
-import pandasai.pandas as pd
+import pandas as pd
 
 llm = OpenAI()
 

--- a/docs/custom-head.md
+++ b/docs/custom-head.md
@@ -4,7 +4,7 @@ In some cases, you might want to share a custom sample head to the LLM. For exam
 
 ```python
 from pandasai import SmartDataframe
-import pandasai.pandas as pd
+import pandas as pd
 
 # head df
 head_df = pd.DataFrame({

--- a/docs/custom-response.md
+++ b/docs/custom-response.md
@@ -9,7 +9,7 @@ You have the option to provide a custom parser, such as `StreamlitResponse`, to 
 ```python
 
 import os
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai import SmartDatalake
 from pandasai.responses.response_parser import ResponseParser
 
@@ -59,7 +59,7 @@ response = agent.chat("Return a dataframe of name against salaries")
 ```python
 
 import os
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai import SmartDatalake
 from pandasai.responses.streamlit_response import StreamlitResponse
 

--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -1,11 +1,8 @@
 # Determinism
-
 ## Introduction
-
 In the realm of Language Model (LM) applications, determinism plays a crucial role, especially when consistent and predictable outcomes are desired. Our library, which integrates multiple LLMs including OpenAI's models, offers users the ability to control this aspect of model behavior through specific parameters like temperature and seed. This document aims to elucidate the importance of these parameters, their usage, and current limitations with different LLM instances such as AzureOpenAI.
 
 ## Why Determinism Matters
-
 Determinism in language models refers to the ability to produce the same output consistently given the same input under identical conditions. This characteristic is vital for:
 
 - Reproducibility: Ensuring the same results can be obtained across different runs, which is crucial for debugging and iterative development.
@@ -13,22 +10,18 @@ Determinism in language models refers to the ability to produce the same output 
 - Testing: Facilitating the evaluation and comparison of models or algorithms by providing a stable ground for testing.
 
 ## The Role of temperature=0
-
 The temperature parameter in language models controls the randomness of the output. A higher temperature increases diversity and creativity in responses, while a lower temperature makes the model more predictable and conservative. Setting `temperature=0` essentially turns off randomness, leading the model to choose the most likely next word at each step. This is critical for achieving determinism as it minimizes variance in the model's output.
 
 ## Implications of temperature=0
-
 - Predictable Responses: The model will consistently choose the most probable path, leading to high predictability in outputs.
 - Creativity: The trade-off for predictability is reduced creativity and variation in responses, as the model won't explore less likely options.
 
 ## Utilizing seed for Enhanced Control
-
 The seed parameter is another tool to enhance determinism. It sets the initial state for the random number generator used in the model, ensuring that the same sequence of "random" numbers is used for each run. This parameter, when combined with `temperature=0`, offers an even higher degree of predictability.
 
 ## Example:
-
 ```py
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai import SmartDataframe
 from pandasai.llm import OpenAI
 
@@ -51,18 +44,15 @@ df.chat('Which are the 5 happiest countries?') # answer should me (mostly) consi
 ```
 
 ## Current Limitation:
-
 ### AzureOpenAI Instance
-
 While the seed parameter is effective with the OpenAI instance in our library, it's important to note that this functionality is not yet available for AzureOpenAI. Users working with AzureOpenAI can still use `temperature=0` to reduce randomness but without the added predictability that seed offers.
 
 ### System fingerprint
-
 As mentioned in the documentation ([OpenAI Seed](https://platform.openai.com/docs/guides/text-generation/reproducible-outputs)) :
-
 > Sometimes, determinism may be impacted due to necessary changes OpenAI makes to model configurations on our end. To help you keep track of these changes, we expose the system_fingerprint field. If this value is different, you may see different outputs due to changes we've made on our systems.
 
 ## Workarounds and Future Updates
-
 For AzureOpenAI Users: Rely on `temperature=0` for reducing randomness. Stay tuned for future updates as we work towards integrating seed functionality with AzureOpenAI.
 For OpenAI Users: Utilize both `temperature=0` and seed for maximum determinism.
+
+

--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -1,8 +1,11 @@
 # Determinism
+
 ## Introduction
+
 In the realm of Language Model (LM) applications, determinism plays a crucial role, especially when consistent and predictable outcomes are desired. Our library, which integrates multiple LLMs including OpenAI's models, offers users the ability to control this aspect of model behavior through specific parameters like temperature and seed. This document aims to elucidate the importance of these parameters, their usage, and current limitations with different LLM instances such as AzureOpenAI.
 
 ## Why Determinism Matters
+
 Determinism in language models refers to the ability to produce the same output consistently given the same input under identical conditions. This characteristic is vital for:
 
 - Reproducibility: Ensuring the same results can be obtained across different runs, which is crucial for debugging and iterative development.
@@ -10,16 +13,20 @@ Determinism in language models refers to the ability to produce the same output 
 - Testing: Facilitating the evaluation and comparison of models or algorithms by providing a stable ground for testing.
 
 ## The Role of temperature=0
+
 The temperature parameter in language models controls the randomness of the output. A higher temperature increases diversity and creativity in responses, while a lower temperature makes the model more predictable and conservative. Setting `temperature=0` essentially turns off randomness, leading the model to choose the most likely next word at each step. This is critical for achieving determinism as it minimizes variance in the model's output.
 
 ## Implications of temperature=0
+
 - Predictable Responses: The model will consistently choose the most probable path, leading to high predictability in outputs.
 - Creativity: The trade-off for predictability is reduced creativity and variation in responses, as the model won't explore less likely options.
 
 ## Utilizing seed for Enhanced Control
+
 The seed parameter is another tool to enhance determinism. It sets the initial state for the random number generator used in the model, ensuring that the same sequence of "random" numbers is used for each run. This parameter, when combined with `temperature=0`, offers an even higher degree of predictability.
 
 ## Example:
+
 ```py
 import pandas as pd
 from pandasai import SmartDataframe
@@ -44,15 +51,18 @@ df.chat('Which are the 5 happiest countries?') # answer should me (mostly) consi
 ```
 
 ## Current Limitation:
+
 ### AzureOpenAI Instance
+
 While the seed parameter is effective with the OpenAI instance in our library, it's important to note that this functionality is not yet available for AzureOpenAI. Users working with AzureOpenAI can still use `temperature=0` to reduce randomness but without the added predictability that seed offers.
 
 ### System fingerprint
+
 As mentioned in the documentation ([OpenAI Seed](https://platform.openai.com/docs/guides/text-generation/reproducible-outputs)) :
+
 > Sometimes, determinism may be impacted due to necessary changes OpenAI makes to model configurations on our end. To help you keep track of these changes, we expose the system_fingerprint field. If this value is different, you may see different outputs due to changes we've made on our systems.
 
 ## Workarounds and Future Updates
+
 For AzureOpenAI Users: Rely on `temperature=0` for reducing randomness. Stay tuned for future updates as we work towards integrating seed functionality with AzureOpenAI.
 For OpenAI Users: Utilize both `temperature=0` and seed for maximum determinism.
-
-

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,7 +10,7 @@ Using PandasAI with a Pandas DataFrame
 ```python
 import os
 from pandasai import SmartDataframe
-import pandasai.pandas as pd
+import pandas as pd
 
 # pandas dataframe
 sales_by_country = pd.DataFrame({
@@ -244,7 +244,7 @@ Example of using PandasAI with multiple dataframes. In order to use multiple dat
 ```python
 import os
 from pandasai import SmartDatalake
-import pandasai.pandas as pd
+import pandas as pd
 
 employees_data = {
     'EmployeeID': [1, 2, 3, 4, 5],
@@ -286,7 +286,7 @@ Feel free to initiate conversations, seek clarifications, and explore explanatio
 
 ```python
 import os
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai import Agent
 
 employees_data = {
@@ -356,7 +356,7 @@ You can add customs functions for the agent to use, allowing the agent to expand
 
 ```python
 import os
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai import Agent
 from pandasai.skills import skill
 

--- a/docs/fields-description.md
+++ b/docs/fields-description.md
@@ -23,7 +23,7 @@ connector = BaseConnector(config, name='My Connector', field_descriptions=field_
 Another example using a pandas connector:
 
 ```python
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai.connectors import PandasConnector
 from pandasai import SmartDataframe
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,7 +44,7 @@ The `SmartDataframe` class is the main class of `pandasai`. It is used to intera
 
 ```python
 import os
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai import SmartDataframe
 
 # Sample DataFrame
@@ -101,7 +101,7 @@ Similarly to a `SmartDataframe`, you can instantiate a `SmartDatalake` as follow
 
 ```python
 import os
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai import SmartDatalake
 
 employees_data = {
@@ -140,7 +140,7 @@ To instantiate an agent, you can use the following code:
 ```python
 import os
 from pandasai import Agent
-import pandasai.pandas as pd
+import pandas as pd
 
 # Sample DataFrames
 sales_by_country = pd.DataFrame({

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Once you have installed PandasAI, you can start using it by importing the `Smart
 
 ```python
 import os
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai import Agent
 
 # Sample DataFrame

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -6,7 +6,7 @@ You can add customs functions for the agent to use, allowing the agent to expand
 
 ```python
 import os
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai import Agent
 from pandasai.skills import skill
 
@@ -58,7 +58,7 @@ response = agent.chat("Plot the employee salaries against names")
 
 ```python
 import os
-import pandasai.pandas as pd
+import pandas as pd
 from pandasai import Agent
 from pandasai.skills import skill
 import streamlit as st

--- a/examples/agent.py
+++ b/examples/agent.py
@@ -1,6 +1,7 @@
 import os
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai import Agent
 
 employees_data = {

--- a/examples/from_dataframe.py
+++ b/examples/from_dataframe.py
@@ -2,9 +2,9 @@
 
 import os
 
+import pandas as pd
 from data.sample_dataframe import dataframe
 
-import pandasai.pandas as pd
 from pandasai import Agent
 
 df = pd.DataFrame(dataframe)

--- a/examples/save_chart.py
+++ b/examples/save_chart.py
@@ -2,9 +2,9 @@
 
 import os
 
+import pandas as pd
 from data.sample_dataframe import dataframe
 
-import pandasai.pandas as pd
 from pandasai import Agent
 from pandasai.helpers import path
 

--- a/examples/show_chart.py
+++ b/examples/show_chart.py
@@ -2,9 +2,9 @@
 
 import os
 
+import pandas as pd
 from data.sample_dataframe import dataframe
 
-import pandasai.pandas as pd
 from pandasai import Agent
 
 df = pd.DataFrame(dataframe)

--- a/examples/skills_example.py
+++ b/examples/skills_example.py
@@ -1,6 +1,7 @@
 import os
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai import Agent
 from pandasai.skills import skill
 

--- a/examples/using_flask.py
+++ b/examples/using_flask.py
@@ -6,9 +6,9 @@ flask –-app using_flask.py run
 """
 import os
 
+import pandas as pd
 from flask import Flask, render_template, request
 
-import pandasai.pandas as pd
 from pandasai import SmartDatalake
 from pandasai.responses.response_parser import ResponseParser
 

--- a/examples/using_pandasai_log_server.py
+++ b/examples/using_pandasai_log_server.py
@@ -1,6 +1,7 @@
 import os
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai import Agent
 
 employees_data = {

--- a/examples/using_streamlit.py
+++ b/examples/using_streamlit.py
@@ -6,7 +6,8 @@ streamlit run examples/using_streamlit.py
 """
 import os
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai import Agent
 from pandasai.responses.streamlit_response import StreamlitResponse
 

--- a/examples/using_train.py
+++ b/examples/using_train.py
@@ -17,7 +17,7 @@ print(response)
 # Example #2: train the model with Q/A
 query = "How many loans were paid off?"
 code = """
-import pandasai.pandas as pd
+import pandas as pd
 
 df = dfs[0]
 df['loan_status'].value_counts()

--- a/examples/using_workspace_env.py
+++ b/examples/using_workspace_env.py
@@ -1,6 +1,7 @@
 import os
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai import Agent
 
 employees_data = {

--- a/examples/with_azure.py
+++ b/examples/with_azure.py
@@ -1,8 +1,8 @@
 """Example of using PandasAI with a Pandas DataFrame"""
 
+import pandas as pd
 from data.sample_dataframe import dataframe
 
-import pandasai.pandas as pd
 from pandasai import Agent
 from pandasai.llm import AzureOpenAI
 

--- a/examples/with_multiple_dataframes.py
+++ b/examples/with_multiple_dataframes.py
@@ -2,7 +2,8 @@
 
 import os
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai import Agent
 
 employees_df = pd.DataFrame(

--- a/examples/with_name_and_description.py
+++ b/examples/with_name_and_description.py
@@ -2,9 +2,9 @@
 
 import os
 
+import pandas as pd
 from data.sample_dataframe import dataframe
 
-import pandasai.pandas as pd
 from pandasai import Agent
 
 df = pd.DataFrame(dataframe)

--- a/examples/with_privacy_enforced.py
+++ b/examples/with_privacy_enforced.py
@@ -1,7 +1,8 @@
 """Example of using PandasAI with a Pandas DataFrame"""
 import os
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai import Agent
 
 from .data.sample_dataframe import dataframe

--- a/examples/with_vertexai.py
+++ b/examples/with_vertexai.py
@@ -2,7 +2,8 @@
 
 import os
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai import Agent
 from pandasai.llm import GoogleVertexAI
 

--- a/pandasai/helpers/df_info.py
+++ b/pandasai/helpers/df_info.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-import pandasai.pandas as pd
+import pandas as pd
 
 
 def _import_modin():

--- a/pandasai/pipelines/chat/code_execution.py
+++ b/pandasai/pipelines/chat/code_execution.py
@@ -4,16 +4,14 @@ import traceback
 from collections import defaultdict
 from typing import Any, Callable, Generator, List, Union
 
-import pandasai.pandas as pd
 from pandasai.exceptions import InvalidLLMOutputType, InvalidOutputValueMismatch
 from pandasai.pipelines.logic_unit_output import LogicUnitOutput
 from pandasai.responses.response_serializer import ResponseSerializer
 
-from ...constants import WHITELISTED_BUILTINS
 from ...exceptions import NoResultFoundError
 from ...helpers.logger import Logger
 from ...helpers.node_visitors import AssignmentVisitor, CallVisitor
-from ...helpers.optional import get_environment, import_dependency
+from ...helpers.optional import get_environment
 from ...helpers.output_validator import OutputValidator
 from ...schemas.df_config import Config
 from ..base_logic_unit import BaseLogicUnit

--- a/pandasai/pipelines/chat/code_execution.py
+++ b/pandasai/pipelines/chat/code_execution.py
@@ -4,14 +4,16 @@ import traceback
 from collections import defaultdict
 from typing import Any, Callable, Generator, List, Union
 
+import pandasai.pandas as pd
 from pandasai.exceptions import InvalidLLMOutputType, InvalidOutputValueMismatch
 from pandasai.pipelines.logic_unit_output import LogicUnitOutput
 from pandasai.responses.response_serializer import ResponseSerializer
 
+from ...constants import WHITELISTED_BUILTINS
 from ...exceptions import NoResultFoundError
 from ...helpers.logger import Logger
 from ...helpers.node_visitors import AssignmentVisitor, CallVisitor
-from ...helpers.optional import get_environment
+from ...helpers.optional import get_environment, import_dependency
 from ...helpers.output_validator import OutputValidator
 from ...schemas.df_config import Config
 from ..base_logic_unit import BaseLogicUnit

--- a/tests/integration_tests/test_cricket.py
+++ b/tests/integration_tests/test_cricket.py
@@ -1,6 +1,7 @@
 import unittest
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.agent.base import Agent
 from pandasai.llm import OpenAI
 

--- a/tests/integration_tests/test_gin.py
+++ b/tests/integration_tests/test_gin.py
@@ -1,6 +1,7 @@
 import unittest
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.agent.base import Agent
 from pandasai.llm import OpenAI
 

--- a/tests/integration_tests/test_loan_payments.py
+++ b/tests/integration_tests/test_loan_payments.py
@@ -1,6 +1,7 @@
 import unittest
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.agent.base import Agent
 from pandasai.llm import OpenAI
 

--- a/tests/integration_tests/test_new_york_housing_market.py
+++ b/tests/integration_tests/test_new_york_housing_market.py
@@ -1,6 +1,7 @@
 import unittest
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.agent.base import Agent
 from pandasai.llm import OpenAI
 

--- a/tests/integration_tests/test_spotify.py
+++ b/tests/integration_tests/test_spotify.py
@@ -1,6 +1,7 @@
 import unittest
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.agent import Agent
 from pandasai.llm import OpenAI
 

--- a/tests/unit_tests/_tests_agent.py
+++ b/tests/unit_tests/_tests_agent.py
@@ -1,9 +1,9 @@
 from typing import Optional
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.agent import Agent
 from pandasai.llm.fake import FakeLLM
 from pandasai.prompts.clarification_questions_prompt import ClarificationQuestionPrompt

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -3,10 +3,10 @@ import sys
 from typing import Optional
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
+import pandas as pd
 import pytest
 from langchain import OpenAI
 
-import pandasai.pandas as pd
 from pandasai.agent import Agent
 from pandasai.connectors.sql import (
     PostgreSQLConnector,

--- a/tests/unit_tests/connectors/test_airtable.py
+++ b/tests/unit_tests/connectors/test_airtable.py
@@ -2,7 +2,8 @@ import json
 import unittest
 from unittest.mock import patch
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.connectors import AirtableConnector
 from pandasai.connectors.airtable import AirtableConnectorConfig
 

--- a/tests/unit_tests/connectors/test_databricks.py
+++ b/tests/unit_tests/connectors/test_databricks.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.ee.connectors import DatabricksConnector
 from pandasai.ee.connectors.databricks import DatabricksConnectorConfig
 

--- a/tests/unit_tests/connectors/test_google_big_query.py
+++ b/tests/unit_tests/connectors/test_google_big_query.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.connectors.sql import PostgreSQLConnector
 from pandasai.ee.connectors import GoogleBigQueryConnector
 from pandasai.ee.connectors.google_big_query import GoogleBigQueryConnectorConfig

--- a/tests/unit_tests/connectors/test_pandas.py
+++ b/tests/unit_tests/connectors/test_pandas.py
@@ -1,4 +1,5 @@
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.connectors import PandasConnector
 
 

--- a/tests/unit_tests/connectors/test_snowflake.py
+++ b/tests/unit_tests/connectors/test_snowflake.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.ee.connectors import SnowFlakeConnector
 from pandasai.ee.connectors.snowflake import SnowFlakeConnectorConfig
 

--- a/tests/unit_tests/connectors/test_sql.py
+++ b/tests/unit_tests/connectors/test_sql.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.connectors.sql import (
     MySQLConnector,
     PostgreSQLConnector,

--- a/tests/unit_tests/connectors/test_sqlite.py
+++ b/tests/unit_tests/connectors/test_sqlite.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.connectors import SqliteConnector
 from pandasai.connectors.sql import SqliteConnectorConfig
 

--- a/tests/unit_tests/connectors/test_yahoo_finance.py
+++ b/tests/unit_tests/connectors/test_yahoo_finance.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 import yfinance as yf
 
-import pandasai.pandas as pd
 from pandasai.connectors.yahoo_finance import YahooFinanceConnector
 
 

--- a/tests/unit_tests/helpers/test_anonymizer.py
+++ b/tests/unit_tests/helpers/test_anonymizer.py
@@ -1,4 +1,5 @@
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai.helpers.anonymizer import Anonymizer
 
 

--- a/tests/unit_tests/helpers/test_from_google_sheets.py
+++ b/tests/unit_tests/helpers/test_from_google_sheets.py
@@ -1,6 +1,6 @@
+import pandas as pd
 from pandas.testing import assert_frame_equal
 
-import pandasai.pandas as pd
 from pandasai.helpers import from_google_sheets
 
 

--- a/tests/unit_tests/helpers/test_openai_info.py
+++ b/tests/unit_tests/helpers/test_openai_info.py
@@ -1,8 +1,8 @@
 import os
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.agent import Agent
 from pandasai.helpers import (
     OpenAICallbackHandler,

--- a/tests/unit_tests/pipelines/smart_datalake/test_code_cleaning.py
+++ b/tests/unit_tests/pipelines/smart_datalake/test_code_cleaning.py
@@ -186,7 +186,7 @@ class TestCodeCleaning:
         logger: Logger,
     ):
         with pytest.raises(Exception):
-            output = code_cleaning.execute("1 +", context=context, logger=logger)
+            code_cleaning.execute("1 +", context=context, logger=logger)
 
     def test_clean_code_remove_builtins(
         self,

--- a/tests/unit_tests/pipelines/smart_datalake/test_code_cleaning.py
+++ b/tests/unit_tests/pipelines/smart_datalake/test_code_cleaning.py
@@ -5,9 +5,9 @@ import uuid
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai import Agent
 from pandasai.connectors.pandas import PandasConnector
 from pandasai.connectors.sql import (
@@ -186,7 +186,7 @@ class TestCodeCleaning:
         logger: Logger,
     ):
         with pytest.raises(Exception):
-            code_cleaning.execute("1 +", context=context, logger=logger)
+            output = code_cleaning.execute("1 +", context=context, logger=logger)
 
     def test_clean_code_remove_builtins(
         self,

--- a/tests/unit_tests/pipelines/smart_datalake/test_code_execution.py
+++ b/tests/unit_tests/pipelines/smart_datalake/test_code_execution.py
@@ -2,9 +2,9 @@ import os
 from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.agent.base import Agent
 from pandasai.exceptions import InvalidOutputValueMismatch, NoCodeFoundError
 from pandasai.helpers.logger import Logger

--- a/tests/unit_tests/pipelines/smart_datalake/test_code_generator.py
+++ b/tests/unit_tests/pipelines/smart_datalake/test_code_generator.py
@@ -1,9 +1,9 @@
 from typing import Optional
 from unittest.mock import Mock, patch
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.helpers.logger import Logger
 from pandasai.llm.fake import FakeLLM
 from pandasai.pipelines.chat.code_generator import CodeGenerator

--- a/tests/unit_tests/pipelines/smart_datalake/test_error_prompt_generation.py
+++ b/tests/unit_tests/pipelines/smart_datalake/test_error_prompt_generation.py
@@ -1,9 +1,9 @@
 from typing import Optional
 from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.exceptions import InvalidLLMOutputType
 from pandasai.llm.fake import FakeLLM
 from pandasai.pipelines.chat.error_correction_pipeline.error_prompt_generation import (

--- a/tests/unit_tests/pipelines/smart_datalake/test_prompt_generation.py
+++ b/tests/unit_tests/pipelines/smart_datalake/test_prompt_generation.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.connectors import PandasConnector
 from pandasai.llm.fake import FakeLLM
 from pandasai.pipelines.chat.prompt_generation import PromptGeneration

--- a/tests/unit_tests/pipelines/smart_datalake/test_result_parsing.py
+++ b/tests/unit_tests/pipelines/smart_datalake/test_result_parsing.py
@@ -1,9 +1,9 @@
 from typing import Optional
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.helpers.logger import Logger
 from pandasai.llm.fake import FakeLLM
 from pandasai.pipelines.chat.result_parsing import ResultParsing

--- a/tests/unit_tests/pipelines/smart_datalake/test_result_validation.py
+++ b/tests/unit_tests/pipelines/smart_datalake/test_result_validation.py
@@ -1,9 +1,9 @@
 from typing import Optional
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.helpers.logger import Logger
 from pandasai.llm.fake import FakeLLM
 from pandasai.pipelines.chat.result_validation import ResultValidation

--- a/tests/unit_tests/pipelines/smart_datalake/test_validate_pipeline_input.py
+++ b/tests/unit_tests/pipelines/smart_datalake/test_validate_pipeline_input.py
@@ -1,9 +1,9 @@
 from typing import Optional
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.connectors.sql import (
     PostgreSQLConnector,
     SQLConnector,

--- a/tests/unit_tests/pipelines/test_pipeline.py
+++ b/tests/unit_tests/pipelines/test_pipeline.py
@@ -1,9 +1,9 @@
 from typing import Any, Optional
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.connectors import BaseConnector, PandasConnector
 from pandasai.llm.fake import FakeLLM
 from pandasai.pipelines.base_logic_unit import BaseLogicUnit

--- a/tests/unit_tests/prompts/test_correct_error_prompt.py
+++ b/tests/unit_tests/prompts/test_correct_error_prompt.py
@@ -1,7 +1,8 @@
 """Unit tests for the correct error prompt class"""
 import sys
 
-import pandasai.pandas as pd
+import pandas as pd
+
 from pandasai import Agent
 from pandasai.connectors import PandasConnector
 from pandasai.helpers.dataframe_serializer import DataframeSerializerType

--- a/tests/unit_tests/prompts/test_generate_python_code_prompt.py
+++ b/tests/unit_tests/prompts/test_generate_python_code_prompt.py
@@ -4,9 +4,9 @@ import os
 import sys
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai import Agent
 from pandasai.connectors import PandasConnector
 from pandasai.helpers.dataframe_serializer import DataframeSerializerType

--- a/tests/unit_tests/prompts/test_sql_prompt.py
+++ b/tests/unit_tests/prompts/test_sql_prompt.py
@@ -2,9 +2,9 @@
 import os
 import sys
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai import Agent
 from pandasai.llm.fake import FakeLLM
 from pandasai.prompts.generate_python_code_with_sql import (

--- a/tests/unit_tests/skills/test_skills.py
+++ b/tests/unit_tests/skills/test_skills.py
@@ -2,9 +2,9 @@ import uuid
 from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai import Agent
 from pandasai.helpers.skills_manager import SkillsManager
 from pandasai.llm.fake import FakeLLM

--- a/tests/unit_tests/test_df_info.py
+++ b/tests/unit_tests/test_df_info.py
@@ -1,9 +1,9 @@
 import unittest
 
 import modin.pandas as mpd
+import pandas as pd
 import polars as pl
 
-import pandasai.pandas as pd
 from pandasai.helpers.df_info import df_type
 
 

--- a/tests/unit_tests/test_query_tracker.py
+++ b/tests/unit_tests/test_query_tracker.py
@@ -6,9 +6,9 @@ from typing import Optional
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
+import pandas as pd
 import pytest
 
-import pandasai.pandas as pd
 from pandasai.connectors import PandasConnector
 from pandasai.helpers.query_exec_tracker import QueryExecTracker
 from pandasai.llm.fake import FakeLLM


### PR DESCRIPTION
This PR reverts this [commit](https://github.com/Sinaptik-AI/pandas-ai/commit/331c7df29ed5b545a108c3cccd957bca3e0a3ac1).

**Rationale:** `pandasai.pandas` needs to be imported only within the package. The user is supposed to either import `pandas` or `modin.pandas` according to their desired engine, thus the docs and the examples shouldn't import `pandasai.pandas` but `pandas` (or `modin.pandas`).

 