### PR TITLE
fix:Introduce `_is_python_code` check into `_extract_code`

### DIFF
--- a/pandasai/llm/base.py
+++ b/pandasai/llm/base.py
@@ -69,7 +69,7 @@ class LLM:
     def _polish_code(self, code: str) -> str:
         """
         Polish the code by removing the leading "python" or "py",  \
-        removing the imports and removing trailing spaces and new lines.
+        removing surrounding '`' characters  and removing trailing spaces and new lines.
 
         Args:
             code (str): A string of Python code.
@@ -117,13 +117,14 @@ class LLM:
         """
         code = response
 
-        if separator not in response:
-            raise NoCodeFoundError("No code found in the response")
-
-        if len(code.split(separator)) > 1:
+        # If separator is in the response then we want the code in between only
+        if separator in response and len(code.split(separator)) > 1:
             code = code.split(separator)[1]
-
         code = self._polish_code(code)
+
+        # Even if the separator is not in the response, the output might still be valid python code
+        if not self._is_python_code(code):
+            raise NoCodeFoundError("No code found in the response")
 
         return code
 


### PR DESCRIPTION
* Add tests to cover more cases for `_extract_code` and `_is_python_code`

- [X] Addresses #1128 
- [X] Tests added and passed if fixing a bug or adding a new feature.
- [X] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).


Motivation:
Using a dataframe with a large number of columns, the `LLM()._execute_code` method would fail when asking how many rows there are in the dataframe. The failure would be because the LLM wasn't using triple back ticks to surround the code.

If the LLM produces correct python code, but for some reason does not
preface it with \```, the `LLM()._extract_code` method fails with
NoCodeFoundError.

In this change we first check if the separator is included in the response and we take only the part that is in-between. Then we clean the code from `python/py` statements.
Then we check if it's valid code. This check should pass otherwise executing the code will fail, and it's better to raise an error earlier than later.

With this change, if the LLM produced perfect code without the \``` separator, it would pass and return the code, whereas previously it would fail.
