### PR TITLE
Update openai_info.py:  adding gpt-4o to the list of GPT-4 output

### DIFF
--- a/pandasai/helpers/openai_info.py
+++ b/pandasai/helpers/openai_info.py
@@ -19,6 +19,8 @@ MODEL_COST_PER_1K_TOKENS = {
     "gpt-4-turbo-preview-completion": 0.03,
     "gpt-4-0125-preview-completion": 0.03,
     "gpt-4-1106-preview-completion": 0.03,
+    "gpt-4o-completion": 0.015,
+    "gpt-4o-2024-05-13-completion": 0.015,
     "gpt-4-32k-completion": 0.12,
     "gpt-4-32k-0613-completion": 0.12,
     # GPT-3.5 input


### PR DESCRIPTION
Adding gpt-4o to the list of GPT-4 output.

- [x] Closes #1155.
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).
