### PR TITLE
docs: llms.mdx had outdated info about bambooLLM api key

### DIFF
--- a/docs/llms.mdx
+++ b/docs/llms.mdx
@@ -26,9 +26,7 @@ file, in the `llm_options` param, as it follows:
 
 BambooLLM is the state-of-the-art language model developed by [PandasAI](https://pandas-ai.com) with data analysis in
 mind. It is designed to understand and execute natural language queries related to data analysis, data manipulation, and
-data visualization. It's currently in closed beta and available only to a select group of users, but it will be
-available to the public soon. You can join the
-waitlist [here](https://docs.google.com/forms/d/1RvdGO6dmV9NY2EaNoxmitxQmRYh3oThVRznoXqJBSFI).
+data visualization. You can get your free API key signing up at https://pandabi.ai 
 
 ```python
 from pandasai import SmartDataframe


### PR DESCRIPTION
Description fix proposal.

I found on the docs the link to have the free api key for the Bamboo LLM. So I thought this might be outdated and you might want to make the api key available publicly now. Feel free to refuse it or to fix it if necessary.