### PR TITLE
Fix issue #1257 empty dataframe

### DIFF
--- a/pandasai/connectors/sql.py
+++ b/pandasai/connectors/sql.py
@@ -173,7 +173,7 @@ class SQLConnector(BaseConnector):
                         query_params[f"value_{i}"] = value
 
             if condition_strings:
-                where_clause = " AND ".join(condition_strings)
+                where_clause = " OR ".join(condition_strings)
                 base_query = base_query.where(
                     text(where_clause).bindparams(**query_params)
                 )


### PR DESCRIPTION
- [x] Closes #1257.
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

As described in #1257: considering all possible cases, in `pandasai/connectors/sql.py` the "where clause" needs to use OR instead of AND to ensure all data gets loaded in dfs.