### PR TITLE
Fix Azure OpenAI LLM backend

### DIFF
--- a/pandasai/llm/azure_openai.py
+++ b/pandasai/llm/azure_openai.py
@@ -176,6 +176,7 @@ class AzureOpenAI(BaseOpenAI):
             "azure_deployment": self.deployment_name,
             "azure_ad_token": self.azure_ad_token,
             "azure_ad_token_provider": self.azure_ad_token_provider,
+            "api_key": self.api_token,
         }
         return {**client_params, **super()._client_params}
 


### PR DESCRIPTION
Azure OpenAI api key (when not using active directory authentication) was not being passed to the underlying openai object.

Oneline fix...
