### PR TITLE
Removed _core property on SmartDataframe that causes maximum recursion depth exceeded

### DIFF
--- a/pandasai/smart_dataframe/__init__.py
+++ b/pandasai/smart_dataframe/__init__.py
@@ -264,9 +264,7 @@ class SmartDataframe:
         return self.dataframe.equals(other.dataframe)
 
     def __getattr__(self, name):
-        if name in self._core.__dir__():
-            return getattr(self._core, name)
-        elif name in self.dataframe.__dir__():
+        if name in self.dataframe.__dir__():
             return getattr(self.dataframe, name)
         else:
             return self.__getattribute__(name)


### PR DESCRIPTION
I ran into `RecursionError: maximum recursion depth exceeded` when using SmartDataframe and found the issue is caused by a call to `__getattr__` trying to access `_core` which does not exist, but it calls `__getattr__ ` repeatedly.

There may be something I don't understand in the code here, and that this has a reason to exist, but this solved my problems.

To reproduce the problem, create a smart data frame with e.g.
```python
import os
import pandas as pd
from pandasai import SmartDataframe

# Sample DataFrame
sales_by_country = pd.DataFrame({
    "country": ["United States", "United Kingdom", "France", "Germany", "Italy", "Spain", "Canada", "Australia", "Japan", "China"],
    "revenue": [5000, 3200, 2900, 4100, 2300, 2100, 2500, 2600, 4500, 7000]
})

# By default, unless you choose a different LLM, it will use BambooLLM.
# You can get your free API key signing up at https://pandabi.ai (you can also configure it in your .env file)
os.environ["PANDASAI_API_KEY"] = "<insert_key>"

df = SmartDataframe(sales_by_country)
df.anyproperty
```

to see that it throws this error.

- [ ] Closes #xxxx (Replace xxxx with the GitHub issue number).
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).
