### PR TITLE
Allow Cross-region inference/Inference profile ID

### DIFF
--- a/pandasai/llm/bedrock_claude.py
+++ b/pandasai/llm/bedrock_claude.py
@@ -46,11 +46,13 @@ class BedrockClaude(LLM):
 
     max_tokens: int = 1024
     model: str = "anthropic.claude-3-sonnet-20240229-v1:0"
+    inference_profile_prefix: Optional[str] = None
     temperature: Optional[float] = None
     top_p: Optional[float] = None
     top_k: Optional[float] = None
     stop_sequences: Optional[str] = None
     client: Any
+    
 
     def __init__(self, bedrock_runtime_client, **kwargs):
         for key, val in kwargs.items():
@@ -59,7 +61,7 @@ class BedrockClaude(LLM):
 
         self.client = bedrock_runtime_client
 
-        if self.model not in self._supported__models:
+        if self.model not in self.inference_profile_prefix + self._supported__models:
             raise UnsupportedModelError(self.model)
 
         invoke_model = getattr(self.client, "invoke_model", None)


### PR DESCRIPTION
Allow Cross-region inference/Inference profile ID to allow users from EU or other regions to use bedrock with pandas ai. example
inference_profile_prefix = "eu."

model becomes:
eu.anthropic.claude-3-5-sonnet-20240620-v1:0

- [ ] Closes #xxxx (Replace xxxx with the GitHub issue number).
- [ ] Tests added and passed if fixing a bug or adding a new feature.
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `inference_profile_prefix` to `BedrockClaude` for cross-region inference support.
> 
>   - **Behavior**:
>     - Adds `inference_profile_prefix` attribute to `BedrockClaude` class for cross-region inference.
>     - Modifies model validation in `__init__()` to include `inference_profile_prefix` in model name check.
>   - **Attributes**:
>     - Adds `inference_profile_prefix` as an optional attribute in `BedrockClaude`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Sinaptik-AI%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for ae770510403b97e37be54b0100b45fcc4b5bb5c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->