### PR TITLE
Fixing multiple 'dynamic' constant exports

### DIFF
--- a/client/app/(ee)/settings/logs/page.tsx
+++ b/client/app/(ee)/settings/logs/page.tsx
@@ -14,5 +14,4 @@ export default async function Logs() {
     </div>
   );
 }
-export const dynamic='force-dynamic';
 

--- a/client/app/settings/datasets/[id]/page.tsx
+++ b/client/app/settings/datasets/[id]/page.tsx
@@ -32,5 +32,5 @@ export default async function DatasetDetailsPage({ params }: PageProps) {
     </>
   );
 }
-export const dynamic='force-dynamic';
+
 

--- a/client/app/settings/datasets/page.tsx
+++ b/client/app/settings/datasets/page.tsx
@@ -55,5 +55,5 @@ export default async function Datasets() {
     </div>
   );
 }
-export const dynamic='force-dynamic';
+
 

--- a/client/app/settings/page.tsx
+++ b/client/app/settings/page.tsx
@@ -5,5 +5,5 @@ export const dynamic = 'force-dynamic';
 export default function Home() {
   redirect("/settings/datasets");
 }
-export const dynamic='force-dynamic';
+
 

--- a/client/app/settings/workspaces/addspaces/page.tsx
+++ b/client/app/settings/workspaces/addspaces/page.tsx
@@ -31,5 +31,5 @@ export default async function AddSpaces() {
     </div>
   );
 }
-export const dynamic='force-dynamic';
+
 

--- a/client/app/settings/workspaces/editspaces/page.tsx
+++ b/client/app/settings/workspaces/editspaces/page.tsx
@@ -27,5 +27,5 @@ export default async function EditWorkSpaces({ searchParams }) {
     </div>
   );
 }
-export const dynamic='force-dynamic';
+
 

--- a/client/app/settings/workspaces/page.tsx
+++ b/client/app/settings/workspaces/page.tsx
@@ -50,5 +50,5 @@ export default async function WorkSpaces() {
     </div>
   );
 }
-export const dynamic='force-dynamic';
+
 


### PR DESCRIPTION
Fixing multiple 'dynamic' constant exports. Looks like two people pushed two different fixes for a previous issue which resulted in duplicate exports in all of these files.

- [X] Closes #1394.
- [X] Tests added and passed if fixing a bug or adding a new feature.
- [X] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes duplicate 'dynamic' constant exports in multiple `page.tsx` files to resolve concurrent fix conflicts.
> 
>   - **Fixes**:
>     - Removes duplicate `export const dynamic='force-dynamic';` in `page.tsx` files across various directories, including `(ee)/settings/logs`, `settings/datasets/[id]`, and `settings/workspaces/editspaces`.
>   - **Files Affected**:
>     - `page.tsx` in `(ee)/settings/logs`, `settings/datasets/[id]`, and `settings/workspaces/editspaces` ... and 4 other files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Sinaptik-AI%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for d2ae8e876e5aacf4fa27d2adeaf745b5b4b63833. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->