### PR TITLE
fix: make seaborn as an optional dependency

### DIFF
--- a/pandasai/helpers/dataframe_serializer.py
+++ b/pandasai/helpers/dataframe_serializer.py
@@ -1,8 +1,6 @@
 import json
 from enum import Enum
 
-import yaml
-
 import pandasai.pandas as pd
 
 
@@ -160,6 +158,9 @@ class DataframeSerializer:
 
     def convert_df_to_yml(self, df: pd.DataFrame, extras: dict) -> str:
         json_df = self.convert_df_to_json(df, extras)
+
+        import yaml
+
         yml_str = yaml.dump(json_df, sort_keys=False, allow_unicode=True)
         if "is_direct_sql" in extras and extras["is_direct_sql"]:
             return f"<table>\n{yml_str}\n</table>\n"

--- a/pandasai/helpers/optional.py
+++ b/pandasai/helpers/optional.py
@@ -20,7 +20,6 @@ from pandasai.safe_libs.restricted_matplotlib import RestrictedMatplotlib
 from pandasai.safe_libs.restricted_numpy import RestrictedNumpy
 from pandasai.safe_libs.restricted_pandas import RestrictedPandas
 
-
 if TYPE_CHECKING:
     import types
 

--- a/pandasai/helpers/optional.py
+++ b/pandasai/helpers/optional.py
@@ -19,7 +19,7 @@ from pandasai.safe_libs.restricted_json import RestrictedJson
 from pandasai.safe_libs.restricted_matplotlib import RestrictedMatplotlib
 from pandasai.safe_libs.restricted_numpy import RestrictedNumpy
 from pandasai.safe_libs.restricted_pandas import RestrictedPandas
-from pandasai.safe_libs.restricted_seaborn import RestrictedSeaborn
+
 
 if TYPE_CHECKING:
     import types
@@ -80,6 +80,8 @@ def get_environment(additional_deps: List[dict]) -> dict:
 
     for lib in additional_deps:
         if lib["name"] == "seaborn":
+            from pandasai.safe_libs.restricted_seaborn import RestrictedSeaborn
+
             env["sns"] = RestrictedSeaborn()
 
         if lib["name"] == "datetime":


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make `seaborn` and `yaml` optional dependencies by conditionally importing them in `optional.py` and `dataframe_serializer.py`.
> 
>   - **Dependencies**:
>     - Make `seaborn` optional by moving `RestrictedSeaborn` import inside a conditional block in `optional.py`.
>     - Make `yaml` optional by moving its import inside `convert_df_to_yml()` in `dataframe_serializer.py`.
>   - **Environment Setup**:
>     - Update `get_environment()` in `optional.py` to import `RestrictedSeaborn` only if `seaborn` is in `additional_deps`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Sinaptik-AI%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 97ed1797f1f5c3d591ed0d94af1ab6a35fafac95. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->