### PR TITLE
fix: sanitize name of dataset in pai.load

### DIFF
--- a/pandasai/data_loader/loader.py
+++ b/pandasai/data_loader/loader.py
@@ -12,6 +12,7 @@ from pandasai.dataframe.base import DataFrame
 from pandasai.dataframe.virtual_dataframe import VirtualDataFrame
 from pandasai.exceptions import InvalidDataSourceType
 from pandasai.helpers.path import find_project_root
+from pandasai.helpers.sql_sanitizer import sanitize_sql_table_name
 
 from ..constants import (
     LOCAL_SOURCE_TYPES,
@@ -78,6 +79,7 @@ class DatasetLoader:
 
         with open(schema_path, "r") as file:
             raw_schema = yaml.safe_load(file)
+            raw_schema["name"] = sanitize_sql_table_name(raw_schema["name"])
             self.schema = SemanticLayerSchema(**raw_schema)
 
     def _get_loader_function(self, source_type: str):

--- a/tests/unit_tests/dataframe/test_loader.py
+++ b/tests/unit_tests/dataframe/test_loader.py
@@ -146,6 +146,17 @@ class TestDatasetLoader:
             loader._load_schema()
             assert loader.schema == mysql_schema
 
+    def test_load_schema_mysql_sanitized_name(self, mysql_schema):
+        mysql_schema.name = "non-sanitized-name"
+
+        with patch("os.path.exists", return_value=True), patch(
+            "builtins.open", mock_open(read_data=str(mysql_schema.to_yaml()))
+        ):
+            loader = DatasetLoader()
+            loader.dataset_path = "test/users"
+            loader._load_schema()
+            assert loader.schema.name == "non_sanitized_name"
+
     def test_load_schema_file_not_found(self):
         with patch("os.path.exists", return_value=False):
             loader = DatasetLoader()


### PR DESCRIPTION
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sanitize dataset name in `_load_schema()` in `loader.py` to prevent SQL injection or invalid table names.
> 
>   - **Behavior**:
>     - Sanitize dataset name in `_load_schema()` in `loader.py` using `sanitize_sql_table_name` to prevent SQL injection or invalid table names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Sinaptik-AI%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 059533d3b490bd9a45177bda30b941b1b4c134a1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->