### PR TITLE
fix(sql): dependencies of sql fixed

### DIFF
--- a/extensions/connectors/sql/poetry.lock
+++ b/extensions/connectors/sql/poetry.lock
@@ -138,7 +138,7 @@ files = [
 name = "cockroachdb"
 version = "0.3.5"
 description = "CockroachDB adapter for SQLAlchemy"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "cockroachdb-0.3.5-py3-none-any.whl", hash = "sha256:b09904b0381386102f6a613173e7b0ffa01addd56606dd4c807601e14fa054d3"},
@@ -1270,7 +1270,7 @@ testing = ["pytest", "pytest-benchmark"]
 name = "psycopg2-binary"
 version = "2.9.10"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "psycopg2-binary-2.9.10.tar.gz", hash = "sha256:4b3df0e6990aa98acda57d983942eff13d824135fe2250e6522edaa782a06de2"},
@@ -1526,7 +1526,7 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 name = "pymysql"
 version = "1.1.1"
 description = "Pure Python MySQL Driver"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "PyMySQL-1.1.1-py3-none-any.whl", hash = "sha256:4de15da4c61dc132f4fb9ab763063e693d521a80fd0e87943b9a453dd4c19d6c"},
@@ -2345,12 +2345,11 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-cockroach = []
-mysql = []
-postgres = []
-sqlite = []
+cockroach = ["cockroachdb"]
+mysql = ["pymysql"]
+postgres = ["psycopg2-binary"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "7b27e1adc27a0cb2b6f12783247ee8adff1e75fa29a3f71efb24fcc79f4dd063"
+content-hash = "502c167e75d0db37009896b1b98f9b791d99a9a2af960f083b192688932b261e"

--- a/extensions/connectors/sql/pyproject.toml
+++ b/extensions/connectors/sql/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandasai-sql"
-version = "0.1.4"
+version = "0.1.5"
 description = "SQL integration for PandaAI"
 authors = ["Gabriele Venturi"]
 license = "MIT"
@@ -11,12 +11,14 @@ python = ">=3.9,<3.12"
 pandasai = ">=3.0.0b4"
 sqlalchemy = "^2.0.0"
 numpy = ">=1.23.2,<2.0.0"
+psycopg2-binary = { version = "^2.9.10", optional = true }
+pymysql = { version = "^1.1.1", optional = true }
+cockroachdb = { version = "^0.3.5", optional = true }
 
 [tool.poetry.extras]
 postgres = ["psycopg2-binary"]
 mysql = ["pymysql"]
 cockroach = ["cockroachdb"]
-sqlite = ["sqlite3"]
 
 [tool.poetry.group.test]
 optional = true
@@ -25,11 +27,6 @@ optional = true
 pytest = "^7.4.0"
 pytest-cov = "^4.1.0"
 pytest-mock = "^3.11.1"
-
-[tool.poetry.group.dev.dependencies]
-pymysql = "^1.1.1"
-psycopg2-binary = "^2.9.10"
-cockroachdb = "^0.3.5"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `pyproject.toml` to adjust dependencies, remove `sqlite` extra, and increment version to 0.1.5.
> 
>   - **Dependencies**:
>     - Move `psycopg2-binary`, `pymysql`, and `cockroachdb` from `dev.dependencies` to main dependencies with optional flags in `pyproject.toml`.
>     - Remove `sqlite` from `extras` in `pyproject.toml`.
>   - **Version**:
>     - Update version from `0.1.4` to `0.1.5` in `pyproject.toml`.
>   - **Misc**:
>     - Adjust `build-backend` line formatting in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 572e628c85383718ea52774f7d9f998a4317b592. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->