### PR TITLE
fix: adding http client parameter in azure_openai.py

### DIFF
--- a/extensions/llms/openai/pandasai_openai/azure_openai.py
+++ b/extensions/llms/openai/pandasai_openai/azure_openai.py
@@ -44,6 +44,7 @@ class AzureOpenAI(BaseOpenAI):
         api_version: Optional[str] = None,
         deployment_name: str = None,
         is_chat_model: bool = True,
+        http_client: str = None,
         **kwargs,
     ):
         """
@@ -103,6 +104,7 @@ class AzureOpenAI(BaseOpenAI):
         self.azure_ad_token_provider = azure_ad_token_provider
         self._is_chat_model = is_chat_model
         self.deployment_name = deployment_name
+        self.http_client = http_client
 
         self.openai_proxy = kwargs.get("openai_proxy") or os.getenv("OPENAI_PROXY")
         if self.openai_proxy:
@@ -138,6 +140,7 @@ class AzureOpenAI(BaseOpenAI):
             "azure_ad_token": self.azure_ad_token,
             "azure_ad_token_provider": self.azure_ad_token_provider,
             "api_key": self.api_token,
+            "http_client": self.http_client,
         }
         return {**client_params, **super()._client_params}
 

--- a/extensions/llms/openai/tests/test_azure_openai.py
+++ b/extensions/llms/openai/tests/test_azure_openai.py
@@ -2,6 +2,7 @@
 import openai
 import pytest
 from pandasai_openai import AzureOpenAI
+import httpx
 
 from pandasai.exceptions import APIKeyNotFoundError, MissingModelError
 
@@ -37,6 +38,18 @@ class TestAzureOpenAILLM:
                 azure_endpoint="test",
                 api_version="test",
                 deployment_name="test",
+            ).type
+            == "azure-openai"
+        )
+
+    def test_type_with_http_client(self):
+        assert (
+            AzureOpenAI(
+                api_token="test",
+                azure_endpoint="test",
+                api_version="test",
+                deployment_name="test",
+                http_client=httpx.Client(verify=False)
             ).type
             == "azure-openai"
         )


### PR DESCRIPTION
Adding http client parameter in azure_openai.py for extending httpx client proxy and ssl configurations for openai

- [ ] Closes #xxxx (Replace xxxx with the GitHub issue number).
- [ ] Tests added and passed if fixing a bug or adding a new feature.
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `http_client` parameter to `AzureOpenAI` for custom HTTP client configurations.
> 
>   - **Behavior**:
>     - Add `http_client` parameter to `AzureOpenAI.__init__()` for custom HTTP client configurations.
>     - Include `http_client` in `_client_params()` for proxy and SSL settings.
>   - **Misc**:
>     - No changes to existing functionality or other methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for c7ad438b1d1b963bbeedf55e2bcad0d716044e53. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->