### PR TITLE
fix(sql): allow paramerized query through sql sanitization

### DIFF
--- a/extensions/connectors/sql/pandasai_sql/__init__.py
+++ b/extensions/connectors/sql/pandasai_sql/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 
 import pandas as pd
@@ -17,7 +18,11 @@ def load_from_mysql(
         database=connection_info.database,
         port=connection_info.port,
     )
-    return pd.read_sql(query, conn, params=params)
+    # Suppress warnings of SqlAlchemy
+    # TODO - Later can be removed when SqlAlchemy is to used
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        return pd.read_sql(query, conn, params=params)
 
 
 def load_from_postgres(
@@ -32,7 +37,11 @@ def load_from_postgres(
         dbname=connection_info.database,
         port=connection_info.port,
     )
-    return pd.read_sql(query, conn, params=params)
+    # Suppress warnings of SqlAlchemy
+    # TODO - Later can be removed when SqlAlchemy is to used
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        return pd.read_sql(query, conn, params=params)
 
 
 def load_from_cockroachdb(
@@ -47,7 +56,11 @@ def load_from_cockroachdb(
         dbname=connection_info.database,
         port=connection_info.port,
     )
-    return pd.read_sql(query, conn, params=params)
+    # Suppress warnings of SqlAlchemy
+    # TODO - Later can be removed when SqlAlchemy is to used
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        return pd.read_sql(query, conn, params=params)
 
 
 __all__ = [

--- a/pandasai/data_loader/sql_loader.py
+++ b/pandasai/data_loader/sql_loader.py
@@ -48,6 +48,12 @@ class SQLDatasetLoader(DatasetLoader):
                 connection_info, formatted_query, params
             )
             return self._apply_transformations(dataframe)
+
+        except ModuleNotFoundError as e:
+            raise ImportError(
+                f"{source_type.capitalize()} connector not found. Please install the pandasai_sql[{source_type}] library.e.g. `pip install pandasai_sql[{source_type}]`"
+            ) from e
+
         except Exception as e:
             raise RuntimeError(
                 f"Failed to execute query for '{source_type}' with: {formatted_query}"

--- a/pandasai/data_loader/sql_loader.py
+++ b/pandasai/data_loader/sql_loader.py
@@ -51,7 +51,7 @@ class SQLDatasetLoader(DatasetLoader):
 
         except ModuleNotFoundError as e:
             raise ImportError(
-                f"{source_type.capitalize()} connector not found. Please install the pandasai_sql[{source_type}] library.e.g. `pip install pandasai_sql[{source_type}]`"
+                f"{source_type.capitalize()} connector not found. Please install the pandasai_sql[{source_type}] library, e.g. `pip install pandasai_sql[{source_type}]`."
             ) from e
 
         except Exception as e:

--- a/pandasai/helpers/sql_sanitizer.py
+++ b/pandasai/helpers/sql_sanitizer.py
@@ -58,8 +58,14 @@ def is_sql_query_safe(query: str) -> bool:
             r"--",
             r"/\*.*\*/",  # Block comments and inline comments
         ]
+
+        placeholder = "___PLACEHOLDER___"  # Temporary placeholder for params
+
+        # Replace '%s' (MySQL, Psycopg2) with a unique placeholder
+        temp_query = query.replace("%s", placeholder)
+
         # Parse the query to extract its structure
-        parsed = sqlglot.parse_one(query)
+        parsed = sqlglot.parse_one(temp_query)
 
         # Ensure the main query is SELECT
         if parsed.key.upper() != "SELECT":

--- a/tests/unit_tests/data_loader/test_sql_loader.py
+++ b/tests/unit_tests/data_loader/test_sql_loader.py
@@ -213,9 +213,12 @@ class TestSqlDatasetLoader:
                 )
             )
             mocked_exec_function.return_value = mock_df
-            mock_loader_function.side_effect = ModuleNotFoundError("Error")
+
+            mock_exec_function = MagicMock()
+            mock_loader_function.return_value = mock_exec_function
+            mock_exec_function.side_effect = ModuleNotFoundError("Error")
             loader = SQLDatasetLoader(mysql_schema, "test/users")
-            mock_sql_query.return_value = False
+            mock_sql_query.return_value = True
             logging.debug("Loading schema from dataset path: %s", loader)
             with pytest.raises(ImportError):
                 loader.execute_query("select * from users")

--- a/tests/unit_tests/helpers/test_sql_sanitizer.py
+++ b/tests/unit_tests/helpers/test_sql_sanitizer.py
@@ -82,6 +82,10 @@ class TestSqlSanitizer:
             query
         )  # Safe query with subquery, no dangerous keyword
 
+    def test_safe_query_with_query_params(self):
+        query = "SELECT * FROM (SELECT * FROM heart_data) AS filtered_data LIMIT %s OFFSET %s"
+        assert is_sql_query_safe(query)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable parameterized queries and suppress SQLAlchemy warnings, with updated tests for query safety and import handling.
> 
>   - **Behavior**:
>     - Allow parameterized queries by replacing '%s' with a placeholder in `is_sql_query_safe()` in `sql_sanitizer.py`.
>     - Suppress SQLAlchemy warnings in `load_from_mysql()`, `load_from_postgres()`, and `load_from_cockroachdb()` in `pandasai_sql/__init__.py`.
>     - Raise `ImportError` in `execute_query()` in `sql_loader.py` if connector is missing.
>   - **Tests**:
>     - Add `test_safe_query_with_query_params()` in `test_sql_sanitizer.py` to verify parameterized query safety.
>     - Add `test_mysql_malicious_with_no_import()` in `test_sql_loader.py` to check handling of missing imports.
>     - Update other tests in `test_sql_loader.py` to cover new behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 8b29e2cbc8dcf550dcdf9ec05da5dec16e436131. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->