### PR TITLE
fix: transpiling sql to specific dialect

### DIFF
--- a/pandasai/data_loader/duck_db_connection_manager.py
+++ b/pandasai/data_loader/duck_db_connection_manager.py
@@ -34,9 +34,7 @@ class DuckDBConnectionManager:
 
     def sql(self, query: str):
         """Executes an SQL query and returns the result as a Pandas DataFrame."""
-        query = SQLParser.transpile_sql_dialect(
-            query, to_dialect="duckdb", from_dialect="mysql"
-        )
+        query = SQLParser.transpile_sql_dialect(query, to_dialect="duckdb")
         return self.connection.sql(query)
 
     def close(self):

--- a/pandasai/data_loader/duck_db_connection_manager.py
+++ b/pandasai/data_loader/duck_db_connection_manager.py
@@ -2,6 +2,8 @@ import weakref
 
 import duckdb
 
+from pandasai.query_builders.sql_parser import SQLParser
+
 
 class DuckDBConnectionManager:
     _instance = None
@@ -32,6 +34,9 @@ class DuckDBConnectionManager:
 
     def sql(self, query: str):
         """Executes an SQL query and returns the result as a Pandas DataFrame."""
+        query = SQLParser.transpile_sql_dialect(
+            query, to_dialect="duckdb", from_dialect="mysql"
+        )
         return self.connection.sql(query)
 
     def close(self):

--- a/pandasai/data_loader/sql_loader.py
+++ b/pandasai/data_loader/sql_loader.py
@@ -11,6 +11,7 @@ from pandasai.query_builders import SqlQueryBuilder
 from ..constants import (
     SUPPORTED_SOURCE_CONNECTORS,
 )
+from ..query_builders.sql_parser import SQLParser
 from .loader import DatasetLoader
 from .semantic_layer_schema import SemanticLayerSchema
 
@@ -40,6 +41,7 @@ class SQLDatasetLoader(DatasetLoader):
         connection_info = self.schema.source.connection
 
         load_function = self._get_loader_function(source_type)
+        query = SQLParser.transpile_sql_dialect(query, to_dialect=source_type)
 
         if not is_sql_query_safe(query):
             raise MaliciousQueryError(

--- a/pandasai/data_loader/view_loader.py
+++ b/pandasai/data_loader/view_loader.py
@@ -10,6 +10,7 @@ from .. import LOCAL_SOURCE_TYPES
 from ..exceptions import MaliciousQueryError
 from ..helpers.sql_sanitizer import is_sql_query_safe
 from ..query_builders.base_query_builder import BaseQueryBuilder
+from ..query_builders.sql_parser import SQLParser
 from .duck_db_connection_manager import DuckDBConnectionManager
 from .loader import DatasetLoader
 from .local_loader import LocalDatasetLoader
@@ -89,6 +90,7 @@ class ViewDatasetLoader(SQLDatasetLoader):
         if source_type in LOCAL_SOURCE_TYPES:
             return self.execute_local_query(query)
         load_function = self._get_loader_function(source_type)
+        query = SQLParser.transpile_sql_dialect(query, to_dialect=source_type)
 
         if not is_sql_query_safe(query):
             raise MaliciousQueryError(

--- a/pandasai/query_builders/sql_parser.py
+++ b/pandasai/query_builders/sql_parser.py
@@ -5,13 +5,6 @@ from sqlglot.optimizer.qualify_columns import quote_identifiers
 
 class SQLParser:
     @staticmethod
-    def extract_table_names(query: str):
-        parsed = sqlglot.parse_one(query)
-        return {
-            table.alias_or_name for table in parsed.find_all(sqlglot.expressions.Table)
-        }
-
-    @staticmethod
     def replace_table_and_column_names(query, table_mapping):
         """
         Transform a SQL query by replacing table names with either new table names or subqueries.
@@ -57,3 +50,10 @@ class SQLParser:
 
         # Convert back to SQL string
         return transformed.sql(pretty=True)
+
+    @staticmethod
+    def transpile_sql_dialect(query, to_dialect, from_dialect=None):
+        query = (
+            parse_one(query, read=from_dialect) if from_dialect else parse_one(query)
+        )
+        return query.sql(dialect=to_dialect, pretty=True)

--- a/tests/unit_tests/data_loader/test_sql_loader.py
+++ b/tests/unit_tests/data_loader/test_sql_loader.py
@@ -153,7 +153,7 @@ LIMIT 5"""
             result = loader.execute_query("SELECT * FROM users")
 
             assert isinstance(result, DataFrame)
-            mock_sql_query.assert_called_once_with("SELECT * FROM users")
+            mock_sql_query.assert_called_once_with("SELECT\n  *\nFROM users")
 
     def test_mysql_malicious_with_no_import(self, mysql_schema):
         """Test loading data from a MySQL source creates a VirtualDataFrame and handles queries correctly."""

--- a/tests/unit_tests/query_builders/test_sql_parser.py
+++ b/tests/unit_tests/query_builders/test_sql_parser.py
@@ -56,3 +56,9 @@ JOIN (
     def test_replace_table_names(query, table_mapping, expected):
         result = SQLParser.replace_table_and_column_names(query, table_mapping)
         assert result.strip() == expected.strip()
+
+    def test_mysql_transpilation(self):
+        query = '''SELECT COUNT(*) AS "total_rows"'''
+        expected = """SELECT\n  COUNT(*) AS `total_rows`"""
+        result = SQLParser.transpile_sql_dialect(query, to_dialect="mysql")
+        assert result.strip() == expected.strip()


### PR DESCRIPTION
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add SQL dialect transpilation to data loaders using `SQLParser.transpile_sql_dialect` and update tests accordingly.
> 
>   - **Behavior**:
>     - `SQLParser.transpile_sql_dialect` added to convert SQL queries to specific dialects.
>     - `DuckDBConnectionManager.sql` now transpiles queries from MySQL to DuckDB.
>     - `SQLDatasetLoader.execute_query` and `ViewDatasetLoader.execute_query` transpile queries to the source type.
>   - **Tests**:
>     - Updated `test_sql_loader.py` to check for transpiled query format.
>     - Added `test_mysql_transpilation` in `test_sql_parser.py` to verify SQL dialect conversion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for b98fb7244962a40dc04cf7d2ddfaeb861652a3c3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->