### PR TITLE
fix: fixing datasets naming convention

### DIFF
--- a/pandasai/__init__.py
+++ b/pandasai/__init__.py
@@ -19,7 +19,11 @@ from pandasai.data_loader.semantic_layer_schema import (
     Source,
 )
 from pandasai.exceptions import DatasetNotFound, InvalidConfigError, PandaAIApiKeyError
-from pandasai.helpers.path import find_project_root, get_validated_dataset_path
+from pandasai.helpers.path import (
+    find_project_root,
+    get_validated_dataset_path,
+    transform_dash_to_underscore,
+)
 from pandasai.helpers.session import get_pandaai_session
 from pandasai.query_builders import SqlQueryBuilder
 from pandasai.sandbox.sandbox import Sandbox
@@ -119,6 +123,7 @@ def create(
         raise ValueError("df must be a PandaAI DataFrame")
 
     org_name, dataset_name = get_validated_dataset_path(path)
+    underscore_dataset_name = transform_dash_to_underscore(dataset_name)
     dataset_directory = str(os.path.join(org_name, dataset_name))
 
     schema_path = os.path.join(dataset_directory, "schema.yaml")
@@ -140,7 +145,7 @@ def create(
 
     if df is not None:
         schema = df.schema
-        schema.name = dataset_name
+        schema.name = underscore_dataset_name
         if (
             parsed_columns
         ):  # if no columns are passed it automatically parse the columns from the df
@@ -153,7 +158,7 @@ def create(
     elif view:
         _relation = [Relation(**relation) for relation in relations or ()]
         schema: SemanticLayerSchema = SemanticLayerSchema(
-            name=dataset_name,
+            name=underscore_dataset_name,
             relations=_relation,
             view=True,
             columns=parsed_columns,
@@ -161,7 +166,7 @@ def create(
         )
     elif source.get("table"):
         schema: SemanticLayerSchema = SemanticLayerSchema(
-            name=dataset_name,
+            name=underscore_dataset_name,
             source=Source(**source),
             columns=parsed_columns,
             group_by=group_by,

--- a/pandasai/data_loader/loader.py
+++ b/pandasai/data_loader/loader.py
@@ -6,7 +6,10 @@ import yaml
 
 from pandasai.dataframe.base import DataFrame
 from pandasai.exceptions import MethodNotImplementedError
-from pandasai.helpers.path import get_validated_dataset_path
+from pandasai.helpers.path import (
+    get_validated_dataset_path,
+    transform_underscore_to_dash,
+)
 from pandasai.helpers.sql_sanitizer import sanitize_sql_table_name
 
 from .. import ConfigManager
@@ -60,6 +63,7 @@ class DatasetLoader(ABC):
         """
         Factory method to create the appropriate loader based on the dataset type.
         """
+        dataset_path = transform_underscore_to_dash(dataset_path)
         schema = cls._read_schema_file(dataset_path)
         return DatasetLoader.create_loader_from_schema(schema, dataset_path)
 
@@ -74,7 +78,6 @@ class DatasetLoader(ABC):
 
         schema_file = file_manager.load(schema_path)
         raw_schema = yaml.safe_load(schema_file)
-        raw_schema["name"] = sanitize_sql_table_name(raw_schema["name"])
         return SemanticLayerSchema(**raw_schema)
 
     def load(self) -> DataFrame:

--- a/pandasai/dataframe/base.py
+++ b/pandasai/dataframe/base.py
@@ -10,6 +10,7 @@ import pandas as pd
 from pandas._typing import Axes, Dtype
 
 import pandasai as pai
+from pandasai import get_validated_dataset_path
 from pandasai.config import Config, ConfigManager
 from pandasai.core.response import BaseResponse
 from pandasai.data_loader.semantic_layer_schema import (
@@ -148,12 +149,15 @@ class DataFrame(pd.DataFrame):
                 "Please save the dataset before pushing to the remote server."
             )
 
+        SemanticLayerSchema.model_validate(self.schema)
+        org_name, dataset_name = get_validated_dataset_path(self.path)
+
         api_key = os.environ.get("PANDABI_API_KEY", None)
 
         request_session = get_pandaai_session()
 
         params = {
-            "path": self.path,
+            "path": f"{org_name}/{dataset_name}",
             "description": self.schema.description,
             "name": self.schema.name,
         }

--- a/pandasai/helpers/path.py
+++ b/pandasai/helpers/path.py
@@ -49,6 +49,21 @@ def validate_name_format(value):
     return bool(re.match(r"^[a-z0-9]+(?:-[a-z0-9]+)*$", value))
 
 
+def validate_underscore_name_format(value):
+    """
+    Validate name format to be 'my_organization'
+    """
+    return bool(re.match(r"^[a-z0-9]+(?:_[a-z0-9]+)*$", value))
+
+
+def transform_dash_to_underscore(value: str) -> str:
+    return value.replace("-", "_")
+
+
+def transform_underscore_to_dash(value: str) -> str:
+    return value.replace("_", "-")
+
+
 def get_validated_dataset_path(path: str):
     # Validate path format
     path_parts = path.split("/")

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -35,7 +35,7 @@ def sample_dataframes():
 @pytest.fixture
 def raw_sample_schema():
     return {
-        "name": "Users",
+        "name": "users",
         "update_frequency": "weekly",
         "columns": [
             {

--- a/tests/unit_tests/dataframe/test_semantic_layer_schema.py
+++ b/tests/unit_tests/dataframe/test_semantic_layer_schema.py
@@ -13,7 +13,7 @@ class TestSemanticLayerSchema:
     def test_valid_schema(self, raw_sample_schema):
         schema = SemanticLayerSchema(**raw_sample_schema)
 
-        assert schema.name == "Users"
+        assert schema.name == "users"
         assert schema.update_frequency == "weekly"
         assert len(schema.columns) == 3
         assert schema.order_by == ["created_at DESC"]
@@ -38,6 +38,12 @@ class TestSemanticLayerSchema:
         assert schema.name == "parent_children"
         assert len(schema.columns) == 3
         assert schema.view == True
+
+    def test_invalid_name(self, raw_sample_schema):
+        raw_sample_schema["name"] = "invalid-name"
+
+        with pytest.raises(ValidationError):
+            SemanticLayerSchema(**raw_sample_schema)
 
     def test_missing_source_path(self, raw_sample_schema):
         raw_sample_schema["source"].pop("path")

--- a/tests/unit_tests/query_builders/test_query_builder.py
+++ b/tests/unit_tests/query_builders/test_query_builder.py
@@ -13,7 +13,7 @@ class TestQueryBuilder:
     @pytest.fixture
     def mysql_schema(self):
         raw_schema = {
-            "name": "Users",
+            "name": "users",
             "update_frequency": "weekly",
             "columns": [
                 {

--- a/tests/unit_tests/test_pandasai_init.py
+++ b/tests/unit_tests/test_pandasai_init.py
@@ -230,6 +230,13 @@ class TestPandaAIInit:
             == 'The dataset "test/dataset" does not exist in your local datasets directory. In addition, no API Key has been provided. Set an API key with valid permits if you want to fetch the dataset from the remote server.'
         )
 
+    def test_load_invalid_name(self):
+        with pytest.raises(
+            ValueError,
+            match="Organization name must be lowercase and use hyphens instead of spaces",
+        ):
+            pandasai.load("test_test/data_set")
+
     def test_clear_cache(self):
         with patch("pandasai.core.cache.Cache.clear") as mock_clear:
             pandasai.clear_cache()
@@ -415,7 +422,7 @@ class TestPandaAIInit:
         from pandasai.data_loader.semantic_layer_schema import Source
 
         schema = SemanticLayerSchema(
-            name="test-dataset",
+            name="test_dataset",
             description="test_description",
             source=Source(type="parquet", path="data.parquet"),
         )


### PR DESCRIPTION
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Standardizes dataset naming conventions to use underscores instead of dashes and ensures lowercase usage, with updates to code and tests for validation and transformation.
> 
>   - **Behavior**:
>     - Enforces dataset names to be lowercase and use underscores instead of dashes in `create()` in `pandasai/__init__.py`.
>     - Updates `push()` in `base.py` to use transformed dataset names.
>     - Adds validation for underscore format in `SemanticLayerSchema` in `semantic_layer_schema.py`.
>   - **Helpers**:
>     - Adds `transform_dash_to_underscore()` and `transform_underscore_to_dash()` in `path.py`.
>     - Adds `validate_underscore_name_format()` in `path.py`.
>   - **Tests**:
>     - Updates tests in `test_loader.py`, `test_semantic_layer_schema.py`, and `test_pandasai_init.py` to reflect new naming conventions.
>     - Adds tests for invalid dataset names in `test_loader.py` and `test_semantic_layer_schema.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 614a9ca5b224d129514aa968c5d741127c26e80f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->