### PR TITLE
fix: passing correct dialect and error to llm

### DIFF
--- a/pandasai/core/prompts/templates/correct_execute_sql_query_usage_error_prompt.tmpl
+++ b/pandasai/core/prompts/templates/correct_execute_sql_query_usage_error_prompt.tmpl
@@ -3,7 +3,10 @@
 The user asked the following question:
 {{context.memory.get_conversation()}}
 
-You generated this python code:
+You generated the following Python code:
 {{code}}
+
+However, it resulted in the following error:
+{{error}}
 
 Fix the python code above and return the new python code but the code generated should use execute_sql_query function

--- a/pandasai/core/prompts/templates/correct_output_type_error_prompt.tmpl
+++ b/pandasai/core/prompts/templates/correct_output_type_error_prompt.tmpl
@@ -3,7 +3,10 @@
 The user asked the following question:
 {{context.memory.get_conversation()}}
 
-You generated this python code:
+You generated the following Python code:
 {{code}}
+
+However, it resulted in the following error:
+{{error}}
 
 Fix the python code above and return the new python code but the result type should be: {{output_type}}

--- a/pandasai/dataframe/base.py
+++ b/pandasai/dataframe/base.py
@@ -141,7 +141,7 @@ class DataFrame(pd.DataFrame):
         """
         source = self.schema.source or None
 
-        if source and source.type in LOCAL_SOURCE_TYPES:
+        if source:
             dialect = "duckdb" if source.type in LOCAL_SOURCE_TYPES else source.type
         else:
             dialect = "postgres"

--- a/pandasai/dataframe/base.py
+++ b/pandasai/dataframe/base.py
@@ -11,6 +11,7 @@ from pandas._typing import Axes, Dtype
 
 import pandasai as pai
 from pandasai import get_validated_dataset_path
+from pandasai.constants import LOCAL_SOURCE_TYPES
 from pandasai.config import Config, ConfigManager
 from pandasai.core.response import BaseResponse
 from pandasai.data_loader.semantic_layer_schema import (
@@ -138,7 +139,14 @@ class DataFrame(pd.DataFrame):
         Returns:
             str: Serialized string representation of the DataFrame
         """
-        return DataframeSerializer.serialize(self)
+        source = self.schema.source or None
+
+        if source and source.type in LOCAL_SOURCE_TYPES:
+            dialect = "duckdb" if source.type in LOCAL_SOURCE_TYPES else source.type
+        else:
+            dialect = "postgres"
+
+        return DataframeSerializer.serialize(self,dialect)
 
     def get_head(self):
         return self.head()

--- a/pandasai/dataframe/base.py
+++ b/pandasai/dataframe/base.py
@@ -11,8 +11,8 @@ from pandas._typing import Axes, Dtype
 
 import pandasai as pai
 from pandasai import get_validated_dataset_path
-from pandasai.constants import LOCAL_SOURCE_TYPES
 from pandasai.config import Config, ConfigManager
+from pandasai.constants import LOCAL_SOURCE_TYPES
 from pandasai.core.response import BaseResponse
 from pandasai.data_loader.semantic_layer_schema import (
     Column,
@@ -146,7 +146,7 @@ class DataFrame(pd.DataFrame):
         else:
             dialect = "postgres"
 
-        return DataframeSerializer.serialize(self,dialect)
+        return DataframeSerializer.serialize(self, dialect)
 
     def get_head(self):
         return self.head()

--- a/tests/unit_tests/prompts/test_sql_prompt.py
+++ b/tests/unit_tests/prompts/test_sql_prompt.py
@@ -64,7 +64,7 @@ class TestGeneratePythonCodeWithSQLPrompt:
             prompt_content
             == f'''<tables>
 
-<table dialect="postgres" table_name="table_d41d8cd98f00b204e9800998ecf8427e" dimensions="0x0">
+<table dialect="duckdb" table_name="table_d41d8cd98f00b204e9800998ecf8427e" dimensions="0x0">
 
 </table>
 


### PR DESCRIPTION
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes SQL dialect determination and error inclusion in prompts for LLM in `pandasai`.
> 
>   - **Behavior**:
>     - Updates `correct_execute_sql_query_usage_error_prompt.tmpl` and `correct_output_type_error_prompt.tmpl` to include error details in the prompt.
>     - Modifies `serialize_dataframe()` in `base.py` to determine SQL dialect based on `source.type`, using `duckdb` for local sources and `postgres` otherwise.
>   - **Imports**:
>     - Adds `LOCAL_SOURCE_TYPES` import in `base.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for b52c11efa0c6bc740d8dc4b89a3d10fbb89e325c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->