### PR TITLE
fix(license): pypi license not displayed for the ee extensions

### DIFF
--- a/extensions/ee/connectors/bigquery/README.md
+++ b/extensions/ee/connectors/bigquery/README.md
@@ -9,3 +9,8 @@ You can install this extension using poetry:
 ```bash
 poetry install pandasai-bigquery
 ```
+
+## License
+
+This package is licensed under the Sinaptik GmbH Enterprise License.  
+For commercial use, please contact [pm@sinaptik.ai](mailto:pm@sinaptik.ai).

--- a/extensions/ee/connectors/bigquery/pyproject.toml
+++ b/extensions/ee/connectors/bigquery/pyproject.toml
@@ -1,9 +1,14 @@
 [tool.poetry]
 name = "pandasai-bigquery"
-version = "0.1.3"
+version = "0.1.4"
 description = "Google BigQuery connector integration for PandaAI"
 authors = ["Gabriele Venturi"]
 readme = "README.md"
+license = "Proprietary"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/v3/data-ingestion"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
@@ -24,3 +29,6 @@ pandasai-sql = { path = "../../../connectors/sql", develop = true }
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.setuptools]
+license-files = ["LICENSE"]

--- a/extensions/ee/connectors/databricks/README.md
+++ b/extensions/ee/connectors/databricks/README.md
@@ -9,3 +9,8 @@ You can install this extension using poetry:
 ```bash
 poetry install pandasai-databricks
 ```
+
+## License
+
+This package is licensed under the Sinaptik GmbH Enterprise License.  
+For commercial use, please contact [pm@sinaptik.ai](mailto:pm@sinaptik.ai).

--- a/extensions/ee/connectors/databricks/pyproject.toml
+++ b/extensions/ee/connectors/databricks/pyproject.toml
@@ -1,9 +1,14 @@
 [tool.poetry]
 name = "pandasai-databricks"
-version = "0.1.3"
+version = "0.1.4"
 description = "Databricks connector integration for PandaAI"
 authors = ["Gabriele Venturi"]
 readme = "README.md"
+license = "Proprietary"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/v3/data-ingestion"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
@@ -25,3 +30,6 @@ jinja2 = "^3.1.3"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.setuptools]
+license-files = ["LICENSE"]

--- a/extensions/ee/connectors/oracle/README.md
+++ b/extensions/ee/connectors/oracle/README.md
@@ -9,3 +9,8 @@ You can install this extension using poetry:
 ```bash
 poetry install pandasai-oracle
 ```
+
+## License
+
+This package is licensed under the Sinaptik GmbH Enterprise License.  
+For commercial use, please contact [pm@sinaptik.ai](mailto:pm@sinaptik.ai).

--- a/extensions/ee/connectors/oracle/pyproject.toml
+++ b/extensions/ee/connectors/oracle/pyproject.toml
@@ -1,9 +1,14 @@
 [tool.poetry]
 name = "pandasai-oracle"
-version = "0.1.3"
+version = "0.1.4"
 description = "Oracle connector integration for PandaAI"
 authors = ["Gabriele Venturi"]
 readme = "README.md"
+license = "Proprietary"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/v3/data-ingestion"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
@@ -23,3 +28,6 @@ pandasai-sql = { path = "../../../connectors/sql", develop = true }
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.setuptools]
+license-files = ["LICENSE"]

--- a/extensions/ee/connectors/snowflake/README.md
+++ b/extensions/ee/connectors/snowflake/README.md
@@ -9,3 +9,8 @@ You can install this extension using poetry:
 ```bash
 poetry install pandasai-snowflake
 ```
+
+## License
+
+This package is licensed under the Sinaptik GmbH Enterprise License.  
+For commercial use, please contact [pm@sinaptik.ai](mailto:pm@sinaptik.ai).

--- a/extensions/ee/connectors/snowflake/pyproject.toml
+++ b/extensions/ee/connectors/snowflake/pyproject.toml
@@ -1,9 +1,14 @@
 [tool.poetry]
 name = "pandasai-snowflake"
-version = "0.1.4"
+version = "0.1.5"
 description = "Snowflake connector integration for PandaAI"
 authors = ["Gabriele Venturi"]
 readme = "README.md"
+license = "Proprietary"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/v3/data-ingestion"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
@@ -23,3 +28,6 @@ pandasai-sql = { path = "../../../connectors/sql", develop = true }
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.setuptools]
+license-files = ["LICENSE"]

--- a/extensions/ee/vectorstores/chromadb/README.md
+++ b/extensions/ee/vectorstores/chromadb/README.md
@@ -9,3 +9,8 @@ You can install this extension using poetry:
 ```bash
 poetry add pandasai-chromadb
 ```
+
+## License
+
+This package is licensed under the Sinaptik GmbH Enterprise License.  
+For commercial use, please contact [pm@sinaptik.ai](mailto:pm@sinaptik.ai).

--- a/extensions/ee/vectorstores/chromadb/pyproject.toml
+++ b/extensions/ee/vectorstores/chromadb/pyproject.toml
@@ -1,9 +1,14 @@
 [tool.poetry]
 name = "pandasai-chromadb"
-version = "0.1.3"
+version = "0.1.4"
 description = "ChromaDB integration for PandaAI"
 authors = ["Gabriele Venturi"]
 readme = "README.md"
+license = "Proprietary"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
@@ -24,3 +29,6 @@ pytest-mock = "^3.11.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.setuptools]
+license-files = ["LICENSE"]

--- a/extensions/ee/vectorstores/lancedb/README.md
+++ b/extensions/ee/vectorstores/lancedb/README.md
@@ -9,3 +9,8 @@ You can install this extension using poetry:
 ```bash
 poetry add pandasai-lancedb
 ```
+
+## License
+
+This package is licensed under the Sinaptik GmbH Enterprise License.  
+For commercial use, please contact [pm@sinaptik.ai](mailto:pm@sinaptik.ai).

--- a/extensions/ee/vectorstores/lancedb/pyproject.toml
+++ b/extensions/ee/vectorstores/lancedb/pyproject.toml
@@ -1,9 +1,14 @@
 [tool.poetry]
 name = "pandasai-lancedb"
-version = "0.1.3"
+version = "0.1.4"
 description = "LanceDB integration for PandaAI"
 authors = ["Gabriele Venturi"]
 readme = "README.md"
+license = "Proprietary"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
@@ -23,3 +28,6 @@ pytest-mock = "^3.11.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.setuptools]
+license-files = ["LICENSE"]

--- a/extensions/ee/vectorstores/milvus/README.md
+++ b/extensions/ee/vectorstores/milvus/README.md
@@ -5,3 +5,8 @@ This extension integrates Milvus with PandaAI, providing vector storage capabili
 ## Installation
 
 You can install this extension using poetry:
+
+## License
+
+This package is licensed under the Sinaptik GmbH Enterprise License.  
+For commercial use, please contact [pm@sinaptik.ai](mailto:pm@sinaptik.ai).

--- a/extensions/ee/vectorstores/milvus/pyproject.toml
+++ b/extensions/ee/vectorstores/milvus/pyproject.toml
@@ -1,9 +1,14 @@
 [tool.poetry]
 name = "pandasai-milvus"
-version = "0.1.3"
+version = "0.1.4"
 description = "Milvus integration for PandaAI"
 authors = ["Gabriele Venturi"]
 readme = "README.md"
+license = "Proprietary"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
@@ -24,3 +29,6 @@ pytest-mock = "^3.11.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.setuptools]
+license-files = ["LICENSE"]

--- a/extensions/ee/vectorstores/pinecone/README.md
+++ b/extensions/ee/vectorstores/pinecone/README.md
@@ -9,3 +9,8 @@ You can install this extension using poetry:
 ```bash
 poetry add pandasai-pinecone
 ```
+
+## License
+
+This package is licensed under the Sinaptik GmbH Enterprise License.  
+For commercial use, please contact [pm@sinaptik.ai](mailto:pm@sinaptik.ai).

--- a/extensions/ee/vectorstores/pinecone/pyproject.toml
+++ b/extensions/ee/vectorstores/pinecone/pyproject.toml
@@ -1,9 +1,14 @@
 [tool.poetry]
 name = "pandasai-pinecone"
-version = "0.1.3"
+version = "0.1.4"
 description = "Pinecone integration for PandaAI"
 authors = ["Gabriele Venturi"]
 readme = "README.md"
+license = "Proprietary"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
@@ -23,3 +28,6 @@ pytest-mock = "^3.11.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.setuptools]
+license-files = ["LICENSE"]

--- a/extensions/ee/vectorstores/qdrant/README.md
+++ b/extensions/ee/vectorstores/qdrant/README.md
@@ -9,3 +9,8 @@ You can install this extension using poetry:
 ```bash
 poetry add pandasai-qdrant
 ```
+
+## License
+
+This package is licensed under the Sinaptik GmbH Enterprise License.  
+For commercial use, please contact [pm@sinaptik.ai](mailto:pm@sinaptik.ai).

--- a/extensions/ee/vectorstores/qdrant/pyproject.toml
+++ b/extensions/ee/vectorstores/qdrant/pyproject.toml
@@ -1,9 +1,14 @@
 [tool.poetry]
 name = "pandasai-qdrant"
-version = "0.1.3"
+version = "0.1.4"
 description = "Qdrant integration for PandaAI"
 authors = ["Gabriele Venturi"]
 readme = "README.md"
+license = "Proprietary"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
@@ -23,3 +28,6 @@ pytest-mock = "^3.11.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.setuptools]
+license-files = ["LICENSE"]

--- a/extensions/llms/bedrock/pyproject.toml
+++ b/extensions/llms/bedrock/pyproject.toml
@@ -1,10 +1,14 @@
 [tool.poetry]
 name = "pandasai-bedrock"
-version = "0.1.4"
+version = "0.1.5"
 description = "AWS Bedrock integration for PandaAI"
 authors = ["Gabriele Venturi"]
 license = "MIT"
 readme = "README.md"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"

--- a/extensions/llms/google/pyproject.toml
+++ b/extensions/llms/google/pyproject.toml
@@ -1,10 +1,14 @@
 [tool.poetry]
 name = "pandasai-google"
-version = "0.1.4"
+version = "0.1.5"
 description = "Google integration for PandaAI"
 authors = ["Gabriele Venturi"]
 license = "MIT"
 readme = "README.md"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"

--- a/extensions/llms/huggingface/pyproject.toml
+++ b/extensions/llms/huggingface/pyproject.toml
@@ -1,10 +1,14 @@
 [tool.poetry]
 name = "pandasai-huggingface"
-version = "0.1.4"
+version = "0.1.5"
 description = "Hugging Face integration for PandaAI"
 authors = ["Gabriele Venturi"]
 license = "MIT"
 readme = "README.md"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"

--- a/extensions/llms/ibm/pyproject.toml
+++ b/extensions/llms/ibm/pyproject.toml
@@ -1,10 +1,14 @@
 [tool.poetry]
 name = "pandasai-ibm"
-version = "0.1.4"
+version = "0.1.5"
 description = "IBM integration for PandaAI"
 authors = ["Gabriele Venturi"]
 license = "MIT"
 readme = "README.md"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"

--- a/extensions/llms/langchain/pyproject.toml
+++ b/extensions/llms/langchain/pyproject.toml
@@ -1,10 +1,14 @@
 [tool.poetry]
 name = "pandasai-langchain"
-version = "0.1.4"
+version = "0.1.5"
 description = "Langchain integration for PandaAI"
 authors = ["Gabriele Venturi"]
 license = "MIT"
 readme = "README.md"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"

--- a/extensions/llms/local/pyproject.toml
+++ b/extensions/llms/local/pyproject.toml
@@ -1,10 +1,14 @@
 [tool.poetry]
 name = "pandasai-local"
-version = "0.1.4"
+version = "0.1.5"
 description = "Local LLM integration for PandaAI"
 authors = ["Gabriele Venturi"]
 license = "MIT"
 readme = "README.md"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"

--- a/extensions/llms/openai/pyproject.toml
+++ b/extensions/llms/openai/pyproject.toml
@@ -1,10 +1,14 @@
 [tool.poetry]
 name = "pandasai-openai"
-version = "0.1.4"
+version = "0.1.5"
 description = "OpenAI integration for PandaAI"
 authors = ["Gabriele Venturi"]
 license = "MIT"
 readme = "README.md"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"

--- a/extensions/sandbox/docker/pyproject.toml
+++ b/extensions/sandbox/docker/pyproject.toml
@@ -1,9 +1,15 @@
 [tool.poetry]
 name = "pandasai-docker"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = ["ArslanSaleem <khan.arslan38@gmail.com>"]
 readme = "README.md"
+license = "MIT"
+
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/v3/privacy-security"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
+
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandasai"
-version = "3.0.0-beta.12"
+version = "3.0.0-beta.13"
 description = "Chat with your database (SQL, CSV, pandas, mongodb, noSQL, etc). PandaAI makes data analysis conversational using LLMs (GPT 3.5 / 4, Anthropic, VertexAI) and RAG."
 authors = ["Gabriele Venturi"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ license = "MIT"
 readme = "README.md"
 packages = [{include = "pandasai"}]
 
+[tool.poetry.urls]
+"Documentation" = "https://docs.getpanda.ai/"
+"Repository" = "https://github.com/sinaptik-ai/pandas-ai"
+
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 python-dotenv = "^1.0.0"
@@ -49,3 +53,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
 exclude = ["tests_*"]
+
+[tool.setuptools]
+license-files = ["LICENSE"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Added license information and updated version numbers for multiple extensions, along with adding documentation and repository URLs in `pyproject.toml`.
> 
>   - **License Information**:
>     - Added license details to `README.md` for `bigquery`, `databricks`, `oracle`, `snowflake`, `chromadb`, `lancedb`, `milvus`, `pinecone`, `qdrant` extensions.
>     - Updated `pyproject.toml` to include `license` field and `license-files` for the same extensions.
>   - **Version Updates**:
>     - Incremented version numbers in `pyproject.toml` for `bigquery`, `databricks`, `oracle`, `snowflake`, `chromadb`, `lancedb`, `milvus`, `pinecone`, `qdrant`, `bedrock`, `google`, `huggingface`, `ibm`, `langchain`, `local`, `openai`, `docker` extensions.
>   - **URLs Addition**:
>     - Added `Documentation` and `Repository` URLs in `pyproject.toml` for all mentioned extensions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 327bccee821cf53742018b2e53f9adfce7dba57c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->