### PR TITLE
docs: update ee license url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ You can find more examples in the [examples](examples) directory.
 
 ## 📜 License
 
-PandaAI is available under the MIT expat license, except for the `pandasai/ee` directory of this repository, which has its [license here](https://github.com/Sinaptik-AI/pandas-ai/blob/master/pandasai/ee/LICENSE).
+PandaAI is available under the MIT expat license, except for the `pandasai/ee` directory of this repository, which has its [license here](https://github.com/sinaptik-ai/pandas-ai/blob/main/ee/LICENSE).
 
 If you are interested in managed PandaAI Cloud or self-hosted Enterprise Offering, [contact us](https://getpanda.ai/pricing).
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update license URL in `README.md` to correct location for `pandasai/ee` license.
> 
>   - **Documentation**:
>     - Update license URL in `README.md` to point to `https://github.com/sinaptik-ai/pandas-ai/blob/main/ee/LICENSE` instead of the previous incorrect URL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 49f9d47ad404b24828fa28aed41c732d06b8035c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->