### PR TITLE
Adding more bedrock Claude models with inference profile

### DIFF
--- a/extensions/llms/bedrock/pandasai_bedrock/claude.py
+++ b/extensions/llms/bedrock/pandasai_bedrock/claude.py
@@ -39,7 +39,6 @@ class BedrockClaude(LLM):
         "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
         "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
     ]
-    ]
     _valid_params = [
         "max_tokens",
         "model",

--- a/extensions/llms/bedrock/pandasai_bedrock/claude.py
+++ b/extensions/llms/bedrock/pandasai_bedrock/claude.py
@@ -34,6 +34,11 @@ class BedrockClaude(LLM):
         "anthropic.claude-3-5-sonnet-20240620-v1:0",
         "anthropic.claude-3-sonnet-20240229-v1:0",
         "anthropic.claude-3-haiku-20240307-v1:0",
+        "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+        "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
+    ]
     ]
     _valid_params = [
         "max_tokens",


### PR DESCRIPTION
Adding the following models:
Claude 3.5 Sonnet v2:
-  us.anthropic.claude-3-5-sonnet-20241022-v2:0
-  apac.anthropic.claude-3-5-sonnet-20241022-v2:0

Claude 3.5 Haiku v1 :
- us.anthropic.claude-3-5-haiku-20241022-v1:0

Claude 3.7 Sonnet v1:
- us.anthropic.claude-3-7-sonnet-20250219-v1:0
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add new Claude models to `_supported__models` in `BedrockClaude` class for text generation.
> 
>   - **Models**:
>     - Add `us.anthropic.claude-3-5-sonnet-20241022-v2:0`, `us.anthropic.claude-3-5-haiku-20241022-v1:0`, `us.anthropic.claude-3-7-sonnet-20250219-v1:0`, and `apac.anthropic.claude-3-5-sonnet-20241022-v2:0` to `_supported__models` in `BedrockClaude` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 6c8ee8f5691263a2e9bf67669baec037d77950c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->