### PR TITLE
fix(query builders): quoting identifiers by default

### DIFF
--- a/pandasai/query_builders/base_query_builder.py
+++ b/pandasai/query_builders/base_query_builder.py
@@ -3,6 +3,7 @@ from typing import List
 import sqlglot
 from sqlglot import select
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
+from sqlglot.optimizer.qualify_columns import quote_identifiers
 
 from pandasai.data_loader.semantic_layer_schema import SemanticLayerSchema, Source
 from pandasai.query_builders.sql_transformation_manager import SQLTransformationManager
@@ -38,7 +39,7 @@ class BaseQueryBuilder:
         if self.schema.limit:
             query = query.limit(self.schema.limit)
 
-        return query.sql(pretty=True)
+        return query.transform(quote_identifiers).sql(pretty=True)
 
     def get_head_query(self, n=5):
         query = select(*self._get_columns()).from_(self._get_table_expression())
@@ -55,7 +56,7 @@ class BaseQueryBuilder:
         # Add LIMIT
         query = query.limit(n)
 
-        return query.sql(pretty=True)
+        return query.transform(quote_identifiers).sql(pretty=True)
 
     def get_row_count(self):
         return select("COUNT(*)").from_(self._get_table_expression()).sql(pretty=True)

--- a/pandasai/query_builders/view_query_builder.py
+++ b/pandasai/query_builders/view_query_builder.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 from sqlglot import exp, expressions, parse_one, select
 from sqlglot.expressions import Subquery
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
+from sqlglot.optimizer.qualify_columns import quote_identifiers
 
 from ..data_loader.loader import DatasetLoader
 from ..data_loader.semantic_layer_schema import SemanticLayerSchema, Transformation
@@ -79,7 +80,7 @@ class ViewQueryBuilder(BaseQueryBuilder):
             query = query.order_by(*self.schema.order_by)
         if self.schema.limit:
             query = query.limit(self.schema.limit)
-        return query.sql(pretty=True)
+        return query.transform(quote_identifiers).sql(pretty=True)
 
     def get_head_query(self, n=5):
         """Get the head query with proper group by column aliasing."""
@@ -89,7 +90,7 @@ class ViewQueryBuilder(BaseQueryBuilder):
             query = query.distinct()
 
         query = query.limit(n)
-        return query.sql(pretty=True)
+        return query.transform(quote_identifiers).sql(pretty=True)
 
     def _get_sub_query_from_loader(self, loader: DatasetLoader) -> Subquery:
         sub_query = parse_one(loader.query_builder.build_query())

--- a/tests/unit_tests/data_loader/test_sql_loader.py
+++ b/tests/unit_tests/data_loader/test_sql_loader.py
@@ -43,12 +43,7 @@ class TestSqlDatasetLoader:
 
             # Verify the SQL query was executed correctly
             mock_execute_query.assert_called_once_with(
-                """SELECT
-  email,
-  first_name,
-  timestamp
-FROM users
-LIMIT 5"""
+                'SELECT\n  "email",\n  "first_name",\n  "timestamp"\nFROM "users"\nLIMIT 5'
             )
 
             # Test executing a custom query

--- a/tests/unit_tests/query_builders/test_group_by.py
+++ b/tests/unit_tests/query_builders/test_group_by.py
@@ -80,14 +80,14 @@ class TestGroupByQueries(unittest.TestCase):
 
         expected = (
             "SELECT\n"
-            "  category,\n"
-            "  region,\n"
-            "  SUM(amount) AS total_sales,\n"
-            "  AVG(quantity) AS avg_quantity\n"
-            "FROM sales\n"
+            '  "category",\n'
+            '  "region",\n'
+            '  SUM("amount") AS "total_sales",\n'
+            '  AVG("quantity") AS "avg_quantity"\n'
+            'FROM "sales"\n'
             "GROUP BY\n"
-            "  category,\n"
-            "  region"
+            '  "category",\n'
+            '  "region"'
         )
         self.assertEqual(query.strip(), expected.strip())
 
@@ -104,14 +104,14 @@ class TestGroupByQueries(unittest.TestCase):
 
             expected = (
                 "SELECT\n"
-                "  category,\n"
-                "  region,\n"
-                "  SUM(amount) AS total_sales,\n"
-                "  AVG(quantity) AS avg_quantity\n"
+                '  "category",\n'
+                '  "region",\n'
+                '  SUM("amount") AS "total_sales",\n'
+                '  AVG("quantity") AS "avg_quantity"\n'
                 "FROM READ_CSV('/mocked/absolute/path')\n"
                 "GROUP BY\n"
-                "  category,\n"
-                "  region"
+                '  "category",\n'
+                '  "region"'
             )
             self.assertEqual(query.strip(), expected.strip())
 
@@ -121,14 +121,14 @@ class TestGroupByQueries(unittest.TestCase):
 
         expected = (
             "SELECT\n"
-            "  category,\n"
-            "  region,\n"
-            "  SUM(amount) AS total_sales,\n"
-            "  AVG(quantity) AS avg_quantity\n"
-            "FROM sales\n"
+            '  "category",\n'
+            '  "region",\n'
+            '  SUM("amount") AS "total_sales",\n'
+            '  AVG("quantity") AS "avg_quantity"\n'
+            'FROM "sales"\n'
             "GROUP BY\n"
-            "  category,\n"
-            "  region"
+            '  "category",\n'
+            '  "region"'
         )
         self.assertEqual(query.strip(), expected.strip())
 
@@ -179,5 +179,5 @@ class TestGroupByQueries(unittest.TestCase):
         builder = BaseQueryBuilder(schema)
         query = builder.build_query()
 
-        expected = "SELECT\n" "  category,\n" "  amount\n" "FROM sales"
+        expected = 'SELECT\n  "category",\n  "amount"\nFROM "sales"'
         self.assertEqual(query.strip(), expected.strip())

--- a/tests/unit_tests/query_builders/test_query_builder.py
+++ b/tests/unit_tests/query_builders/test_query_builder.py
@@ -61,14 +61,16 @@ class TestQueryBuilder:
             mock_config_get.return_value = mock_config
             query_builder = LocalQueryBuilder(sample_schema, "test/test")
             query = query_builder.build_query()
-            expected_query = """SELECT
-  email,
-  first_name,
-  timestamp
-FROM READ_CSV('/mocked/absolute/path')
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+            expected_query = (
+                "SELECT\n"
+                '  "email",\n'
+                '  "first_name",\n'
+                '  "timestamp"\n'
+                "FROM READ_CSV('/mocked/absolute/path')\n"
+                "ORDER BY\n"
+                '  "created_at" DESC\n'
+                "LIMIT 100"
+            )
             assert query == expected_query
 
     def test_build_query_csv_with_transformation(self, raw_sample_schema):
@@ -91,12 +93,12 @@ LIMIT 100"""
             query = query_builder.build_query()
             expected_query = (
                 "SELECT\n"
-                "  MD5(email) AS email,\n"
-                "  first_name AS first_name,\n"
-                "  CONVERT_TZ(timestamp, 'UTC', 'UTC') AS timestamp\n"
+                '  MD5("email") AS "email",\n'
+                '  "first_name" AS "first_name",\n'
+                "  CONVERT_TZ(\"timestamp\", 'UTC', 'UTC') AS \"timestamp\"\n"
                 "FROM READ_CSV('/mocked/absolute/path')\n"
                 "ORDER BY\n"
-                "  created_at DESC\n"
+                '  "created_at" DESC\n'
                 "LIMIT 100"
             )
             assert query == expected_query
@@ -112,27 +114,31 @@ LIMIT 100"""
             mock_config_get.return_value = mock_config
             query_builder = LocalQueryBuilder(sample_schema, "test/test")
             query = query_builder.build_query()
-            expected_query = """SELECT
-  email,
-  first_name,
-  timestamp
-FROM READ_PARQUET('/mocked/absolute/path')
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+            expected_query = (
+                "SELECT\n"
+                '  "email",\n'
+                '  "first_name",\n'
+                '  "timestamp"\n'
+                "FROM READ_PARQUET('/mocked/absolute/path')\n"
+                "ORDER BY\n"
+                '  "created_at" DESC\n'
+                "LIMIT 100"
+            )
             assert query == expected_query
 
     def test_build_query(self, mysql_schema):
         query_builder = SqlQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        expected_query = """SELECT
-  email,
-  first_name,
-  timestamp
-FROM users
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+        expected_query = (
+            "SELECT\n"
+            '  "email",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC\n'
+            "LIMIT 100"
+        )
         assert query == expected_query
 
     def test_build_query_with_transformation(self, raw_mysql_schema):
@@ -148,12 +154,12 @@ LIMIT 100"""
         query = query_builder.build_query()
         expected_query = (
             "SELECT\n"
-            "  MD5(email) AS email,\n"
-            "  first_name AS first_name,\n"
-            "  CONVERT_TZ(timestamp, 'UTC', 'UTC') AS timestamp\n"
-            "FROM users\n"
+            '  MD5("email") AS "email",\n'
+            '  "first_name" AS "first_name",\n'
+            "  CONVERT_TZ(\"timestamp\", 'UTC', 'UTC') AS \"timestamp\"\n"
+            'FROM "users"\n'
             "ORDER BY\n"
-            "  created_at DESC\n"
+            '  "created_at" DESC\n'
             "LIMIT 100"
         )
         assert query == expected_query
@@ -171,88 +177,84 @@ LIMIT 100"""
         mysql_schema.order_by = None
         query_builder = SqlQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        expected_query = """SELECT
-  email,
-  first_name,
-  timestamp
-FROM users
-LIMIT 100"""
+        expected_query = 'SELECT\n  "email",\n  "first_name",\n  "timestamp"\nFROM "users"\nLIMIT 100'
         assert query == expected_query
 
     def test_build_query_without_limit(self, mysql_schema):
         mysql_schema.limit = None
         query_builder = SqlQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        expected_query = """SELECT
-  email,
-  first_name,
-  timestamp
-FROM users
-ORDER BY
-  created_at DESC"""
+        expected_query = (
+            "SELECT\n"
+            '  "email",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC'
+        )
         assert query == expected_query
 
     def test_build_query_with_multiple_order_by(self, mysql_schema):
         mysql_schema.order_by = ["created_at DESC", "email ASC"]
         query_builder = SqlQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        expected_query = """SELECT
-  email,
-  first_name,
-  timestamp
-FROM users
-ORDER BY
-  created_at DESC,
-  email ASC
-LIMIT 100"""
+        expected_query = (
+            "SELECT\n"
+            '  "email",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC,\n'
+            '  "email" ASC\n'
+            "LIMIT 100"
+        )
         assert query == expected_query
 
     def test_table_name_injection(self, mysql_schema):
         mysql_schema.name = "users; DROP TABLE users;"
         query_builder = BaseQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  email,
-  first_name,
-  timestamp
-FROM "users; DROP TABLE users;"
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+        assert query == (
+            "SELECT\n"
+            '  "email",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users; DROP TABLE users;"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC\n'
+            "LIMIT 100"
         )
 
     def test_column_name_injection(self, mysql_schema):
         mysql_schema.columns[0].name = "column; DROP TABLE users;"
         query_builder = BaseQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  "column; DROP TABLE users;",
-  first_name,
-  timestamp
-FROM users
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+        assert query == (
+            "SELECT\n"
+            '  "column; DROP TABLE users;",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC\n'
+            "LIMIT 100"
         )
 
     def test_table_name_union_injection(self, mysql_schema):
         mysql_schema.name = "users UNION SELECT 1,2,3;"
         query_builder = BaseQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  email,
-  first_name,
-  timestamp
-FROM "users UNION SELECT 1,2,3;"
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+        assert query == (
+            "SELECT\n"
+            '  "email",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users UNION SELECT 1,2,3;"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC\n'
+            "LIMIT 100"
         )
 
     def test_column_name_union_injection(self, mysql_schema):
@@ -261,96 +263,90 @@ LIMIT 100"""
         ].name = "column UNION SELECT username, password FROM users;"
         query_builder = BaseQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  "column UNION SELECT username, password FROM users;",
-  first_name,
-  timestamp
-FROM users
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+        assert query == (
+            "SELECT\n"
+            '  "column UNION SELECT username, password FROM users;",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC\n'
+            "LIMIT 100"
         )
 
     def test_table_name_comment_injection(self, mysql_schema):
         mysql_schema.name = "users --"
         query_builder = BaseQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  email,
-  first_name,
-  timestamp
-FROM users
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+        assert query == (
+            "SELECT\n"
+            '  "email",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC\n'
+            "LIMIT 100"
         )
 
     def test_column_name_comment_injection(self, mysql_schema):
         mysql_schema.columns[0].name = "column --"
         query_builder = BaseQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  column,
-  first_name,
-  timestamp
-FROM users
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+        assert query == (
+            "SELECT\n"
+            '  "column",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC\n'
+            "LIMIT 100"
         )
 
     def test_table_name_stacked_query_injection(self, mysql_schema):
         mysql_schema.name = 'users"; SELECT * FROM sensitive_data; --'
         query_builder = BaseQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  email,
-  first_name,
-  timestamp
-FROM "users""; SELECT * FROM sensitive_data; --"
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+        assert query == (
+            "SELECT\n"
+            '  "email",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users""; SELECT * FROM sensitive_data; --"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC\n'
+            "LIMIT 100"
         )
 
     def test_table_name_batch_injection(self, mysql_schema):
         mysql_schema.name = "users; TRUNCATE users; SELECT * FROM users WHERE 't'='t"
         query_builder = BaseQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  email,
-  first_name,
-  timestamp
-FROM "users; TRUNCATE users; SELECT * FROM users WHERE 't'='t"
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+        assert query == (
+            "SELECT\n"
+            '  "email",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            "FROM \"users; TRUNCATE users; SELECT * FROM users WHERE 't'='t\"\n"
+            "ORDER BY\n"
+            '  "created_at" DESC\n'
+            "LIMIT 100"
         )
 
     def test_table_name_time_based_injection(self, mysql_schema):
         mysql_schema.name = "users' AND (SELECT * FROM (SELECT(SLEEP(5)))test); --"
         query_builder = BaseQueryBuilder(mysql_schema)
         query = query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  email,
-  first_name,
-  timestamp
-FROM "users' AND (SELECT * FROM (SELECT(SLEEP(5)))test); --"
-ORDER BY
-  created_at DESC
-LIMIT 100"""
+        assert query == (
+            "SELECT\n"
+            '  "email",\n'
+            '  "first_name",\n'
+            '  "timestamp"\n'
+            'FROM "users\' AND (SELECT * FROM (SELECT(SLEEP(5)))test); --"\n'
+            "ORDER BY\n"
+            '  "created_at" DESC\n'
+            "LIMIT 100"
         )
 
     @pytest.mark.parametrize(
@@ -389,10 +385,10 @@ LIMIT 100"""
         base_query_builder = BaseQueryBuilder(sample_schema)
         base_query_builder.schema.order_by = ["column"]
         result = base_query_builder.build_query()
-        assert "ORDER BY\n  column" in result
+        assert 'ORDER BY\n  "column"' in result
 
     def test_get_group_by_columns(self, sample_schema):
         base_query_builder = BaseQueryBuilder(sample_schema)
         base_query_builder.schema.group_by = ["parents"]
         result = base_query_builder.get_head_query()
-        assert "GROUP BY\n  parents" in result
+        assert 'GROUP BY\n  "parents"' in result

--- a/tests/unit_tests/query_builders/test_sql_transformation_manager.py
+++ b/tests/unit_tests/query_builders/test_sql_transformation_manager.py
@@ -295,11 +295,11 @@ def test_remove_duplicates_transformation():
     )
     head_query = query_builder.get_head_query()
     assert head_query == (
-        "SELECT DISTINCT\n" "  value AS value\n" "FROM table_name\n" "LIMIT 5"
+        'SELECT DISTINCT\n  "value" AS "value"\nFROM "table_name"\nLIMIT 5'
     )
     assert validate_sql(head_query)
     build_query = query_builder.build_query()
-    assert build_query == ("SELECT DISTINCT\n" "  value AS value\n" "FROM table_name")
+    assert build_query == 'SELECT DISTINCT\n  "value" AS "value"\nFROM "table_name"'
     assert validate_sql(build_query)
 
 

--- a/tests/unit_tests/query_builders/test_view_query_builder.py
+++ b/tests/unit_tests/query_builders/test_view_query_builder.py
@@ -48,35 +48,34 @@ class TestViewQueryBuilder:
 
     def test_build_query(self, view_query_builder):
         result = view_query_builder.build_query()
-        assert (
-            result
-            == """SELECT
-  parents_id,
-  parents_name,
-  children_name
-FROM (
-  SELECT
-    parents_id AS parents_id,
-    parents_name AS parents_name,
-    children_name AS children_name
-  FROM (
-    SELECT
-      parents.id AS parents_id,
-      parents.name AS parents_name,
-      children.name AS children_name
-    FROM (
-      SELECT
-        *
-      FROM parents
-    ) AS parents
-    JOIN (
-      SELECT
-        *
-      FROM children
-    ) AS children
-      ON parents.id = children.id
-  )
-) AS parent_children"""
+        assert result == (
+            "SELECT\n"
+            '  "parents_id",\n'
+            '  "parents_name",\n'
+            '  "children_name"\n'
+            "FROM (\n"
+            "  SELECT\n"
+            '    "parents_id" AS "parents_id",\n'
+            '    "parents_name" AS "parents_name",\n'
+            '    "children_name" AS "children_name"\n'
+            "  FROM (\n"
+            "    SELECT\n"
+            '      "parents"."id" AS "parents_id",\n'
+            '      "parents"."name" AS "parents_name",\n'
+            '      "children"."name" AS "children_name"\n'
+            "    FROM (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "parents"\n'
+            '    ) AS "parents"\n'
+            "    JOIN (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "children"\n'
+            '    ) AS "children"\n'
+            '      ON "parents"."id" = "children"."id"\n'
+            "  )\n"
+            ') AS "parent_children"'
         )
 
     def test_build_query_distinct(self, view_query_builder):
@@ -96,7 +95,7 @@ FROM (
     def test_build_query_order_by(self, view_query_builder):
         view_query_builder.schema.order_by = ["column"]
         result = view_query_builder.build_query()
-        assert "ORDER BY\n  column" in result
+        assert 'ORDER BY\n  "column"' in result
 
     def test_build_query_limit(self, view_query_builder):
         view_query_builder.schema.limit = 10
@@ -116,133 +115,129 @@ FROM (
         assert group_by_column == ["parents_id"]
 
     def test_get_table_expression(self, view_query_builder):
-        assert (
-            view_query_builder._get_table_expression()
-            == """(
-  SELECT
-    parents_id AS parents_id,
-    parents_name AS parents_name,
-    children_name AS children_name
-  FROM (
-    SELECT
-      parents.id AS parents_id,
-      parents.name AS parents_name,
-      children.name AS children_name
-    FROM (
-      SELECT
-        *
-      FROM parents
-    ) AS parents
-    JOIN (
-      SELECT
-        *
-      FROM children
-    ) AS children
-      ON parents.id = children.id
-  )
-) AS parent_children"""
+        assert view_query_builder._get_table_expression() == (
+            "(\n"
+            "  SELECT\n"
+            "    parents_id AS parents_id,\n"
+            "    parents_name AS parents_name,\n"
+            "    children_name AS children_name\n"
+            "  FROM (\n"
+            "    SELECT\n"
+            "      parents.id AS parents_id,\n"
+            "      parents.name AS parents_name,\n"
+            "      children.name AS children_name\n"
+            "    FROM (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "parents"\n'
+            "    ) AS parents\n"
+            "    JOIN (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "children"\n'
+            "    ) AS children\n"
+            "      ON parents.id = children.id\n"
+            "  )\n"
+            ") AS parent_children"
         )
 
     def test_table_name_injection(self, view_query_builder):
         view_query_builder.schema.name = "users; DROP TABLE users;"
         query = view_query_builder.build_query()
-        assert (
-            query
-            == '''SELECT
-  parents_id,
-  parents_name,
-  children_name
-FROM (
-  SELECT
-    parents_id AS parents_id,
-    parents_name AS parents_name,
-    children_name AS children_name
-  FROM (
-    SELECT
-      parents.id AS parents_id,
-      parents.name AS parents_name,
-      children.name AS children_name
-    FROM (
-      SELECT
-        *
-      FROM parents
-    ) AS parents
-    JOIN (
-      SELECT
-        *
-      FROM children
-    ) AS children
-      ON parents.id = children.id
-  )
-) AS "users; DROP TABLE users;"'''
+        assert query == (
+            "SELECT\n"
+            '  "parents_id",\n'
+            '  "parents_name",\n'
+            '  "children_name"\n'
+            "FROM (\n"
+            "  SELECT\n"
+            '    "parents_id" AS "parents_id",\n'
+            '    "parents_name" AS "parents_name",\n'
+            '    "children_name" AS "children_name"\n'
+            "  FROM (\n"
+            "    SELECT\n"
+            '      "parents"."id" AS "parents_id",\n'
+            '      "parents"."name" AS "parents_name",\n'
+            '      "children"."name" AS "children_name"\n'
+            "    FROM (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "parents"\n'
+            '    ) AS "parents"\n'
+            "    JOIN (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "children"\n'
+            '    ) AS "children"\n'
+            '      ON "parents"."id" = "children"."id"\n'
+            "  )\n"
+            ') AS "users; DROP TABLE users;"'
         )
 
     def test_column_name_injection(self, view_query_builder):
         view_query_builder.schema.columns[0].name = "column; DROP TABLE users;"
         query = view_query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  column__drop_table_users_,
-  parents_name,
-  children_name
-FROM (
-  SELECT
-    column__drop_table_users_ AS column__drop_table_users_,
-    parents_name AS parents_name,
-    children_name AS children_name
-  FROM (
-    SELECT
-      column__drop_table_users_ AS column__drop_table_users_,
-      parents.name AS parents_name,
-      children.name AS children_name
-    FROM (
-      SELECT
-        *
-      FROM parents
-    ) AS parents
-    JOIN (
-      SELECT
-        *
-      FROM children
-    ) AS children
-      ON parents.id = children.id
-  )
-) AS parent_children"""
+        assert query == (
+            "SELECT\n"
+            '  "column__drop_table_users_",\n'
+            '  "parents_name",\n'
+            '  "children_name"\n'
+            "FROM (\n"
+            "  SELECT\n"
+            '    "column__drop_table_users_" AS "column__drop_table_users_",\n'
+            '    "parents_name" AS "parents_name",\n'
+            '    "children_name" AS "children_name"\n'
+            "  FROM (\n"
+            "    SELECT\n"
+            '      "column__drop_table_users_" AS "column__drop_table_users_",\n'
+            '      "parents"."name" AS "parents_name",\n'
+            '      "children"."name" AS "children_name"\n'
+            "    FROM (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "parents"\n'
+            '    ) AS "parents"\n'
+            "    JOIN (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "children"\n'
+            '    ) AS "children"\n'
+            '      ON "parents"."id" = "children"."id"\n'
+            "  )\n"
+            ') AS "parent_children"'
         )
 
     def test_table_name_union_injection(self, view_query_builder):
         view_query_builder.schema.name = "users UNION SELECT 1,2,3;"
         query = view_query_builder.build_query()
-        assert (
-            query
-            == '''SELECT
-  parents_id,
-  parents_name,
-  children_name
-FROM (
-  SELECT
-    parents_id AS parents_id,
-    parents_name AS parents_name,
-    children_name AS children_name
-  FROM (
-    SELECT
-      parents.id AS parents_id,
-      parents.name AS parents_name,
-      children.name AS children_name
-    FROM (
-      SELECT
-        *
-      FROM parents
-    ) AS parents
-    JOIN (
-      SELECT
-        *
-      FROM children
-    ) AS children
-      ON parents.id = children.id
-  )
-) AS "users UNION SELECT 1,2,3;"'''
+        assert query == (
+            "SELECT\n"
+            '  "parents_id",\n'
+            '  "parents_name",\n'
+            '  "children_name"\n'
+            "FROM (\n"
+            "  SELECT\n"
+            '    "parents_id" AS "parents_id",\n'
+            '    "parents_name" AS "parents_name",\n'
+            '    "children_name" AS "children_name"\n'
+            "  FROM (\n"
+            "    SELECT\n"
+            '      "parents"."id" AS "parents_id",\n'
+            '      "parents"."name" AS "parents_name",\n'
+            '      "children"."name" AS "children_name"\n'
+            "    FROM (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "parents"\n'
+            '    ) AS "parents"\n'
+            "    JOIN (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "children"\n'
+            '    ) AS "children"\n'
+            '      ON "parents"."id" = "children"."id"\n'
+            "  )\n"
+            ') AS "users UNION SELECT 1,2,3;"'
         )
 
     def test_column_name_union_injection(self, view_query_builder):
@@ -250,69 +245,69 @@ FROM (
             0
         ].name = "column UNION SELECT username, password FROM users;"
         query = view_query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  column_union_select_username__password_from_users_,
-  parents_name,
-  children_name
-FROM (
-  SELECT
-    column_union_select_username__password_from_users_ AS column_union_select_username__password_from_users_,
-    parents_name AS parents_name,
-    children_name AS children_name
-  FROM (
-    SELECT
-      column_union_select_username__password_from_users_ AS column_union_select_username__password_from_users_,
-      parents.name AS parents_name,
-      children.name AS children_name
-    FROM (
-      SELECT
-        *
-      FROM parents
-    ) AS parents
-    JOIN (
-      SELECT
-        *
-      FROM children
-    ) AS children
-      ON parents.id = children.id
-  )
-) AS parent_children"""
+        assert query == (
+            "SELECT\n"
+            '  "column_union_select_username__password_from_users_",\n'
+            '  "parents_name",\n'
+            '  "children_name"\n'
+            "FROM (\n"
+            "  SELECT\n"
+            '    "column_union_select_username__password_from_users_" AS '
+            '"column_union_select_username__password_from_users_",\n'
+            '    "parents_name" AS "parents_name",\n'
+            '    "children_name" AS "children_name"\n'
+            "  FROM (\n"
+            "    SELECT\n"
+            '      "column_union_select_username__password_from_users_" AS '
+            '"column_union_select_username__password_from_users_",\n'
+            '      "parents"."name" AS "parents_name",\n'
+            '      "children"."name" AS "children_name"\n'
+            "    FROM (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "parents"\n'
+            '    ) AS "parents"\n'
+            "    JOIN (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "children"\n'
+            '    ) AS "children"\n'
+            '      ON "parents"."id" = "children"."id"\n'
+            "  )\n"
+            ') AS "parent_children"'
         )
 
     def test_table_name_comment_injection(self, view_query_builder):
         view_query_builder.schema.name = "users --"
         query = view_query_builder.build_query()
-        assert (
-            query
-            == """SELECT
-  parents_id,
-  parents_name,
-  children_name
-FROM (
-  SELECT
-    parents_id AS parents_id,
-    parents_name AS parents_name,
-    children_name AS children_name
-  FROM (
-    SELECT
-      parents.id AS parents_id,
-      parents.name AS parents_name,
-      children.name AS children_name
-    FROM (
-      SELECT
-        *
-      FROM parents
-    ) AS parents
-    JOIN (
-      SELECT
-        *
-      FROM children
-    ) AS children
-      ON parents.id = children.id
-  )
-) AS users"""
+        assert query == (
+            "SELECT\n"
+            '  "parents_id",\n'
+            '  "parents_name",\n'
+            '  "children_name"\n'
+            "FROM (\n"
+            "  SELECT\n"
+            '    "parents_id" AS "parents_id",\n'
+            '    "parents_name" AS "parents_name",\n'
+            '    "children_name" AS "children_name"\n'
+            "  FROM (\n"
+            "    SELECT\n"
+            '      "parents"."id" AS "parents_id",\n'
+            '      "parents"."name" AS "parents_name",\n'
+            '      "children"."name" AS "children_name"\n'
+            "    FROM (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "parents"\n'
+            '    ) AS "parents"\n'
+            "    JOIN (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "children"\n'
+            '    ) AS "children"\n'
+            '      ON "parents"."id" = "children"."id"\n'
+            "  )\n"
+            ') AS "users"'
         )
 
     def test_multiple_joins_same_table(self):
@@ -354,12 +349,12 @@ FROM (
             "    FROM (\n"
             "      SELECT\n"
             "        *\n"
-            "      FROM diabetes\n"
+            '      FROM "diabetes"\n'
             "    ) AS diabetes\n"
             "    JOIN (\n"
             "      SELECT\n"
             "        *\n"
-            "      FROM heart\n"
+            '      FROM "heart"\n'
             "    ) AS heart\n"
             "      ON diabetes.age = heart.age AND diabetes.bloodpressure = "
             "heart.restingbp\n"
@@ -408,12 +403,12 @@ FROM (
             "    FROM (\n"
             "      SELECT\n"
             "        *\n"
-            "      FROM diabetes\n"
+            '      FROM "diabetes"\n'
             "    ) AS diabetes\n"
             "    JOIN (\n"
             "      SELECT\n"
             "        *\n"
-            "      FROM heart\n"
+            '      FROM "heart"\n'
             "    ) AS heart\n"
             "      ON diabetes.age = heart.age AND diabetes.bloodpressure = "
             "heart.restingbp\n"
@@ -458,18 +453,18 @@ FROM (
             "    FROM (\n"
             "      SELECT\n"
             "        *\n"
-            "      FROM patients\n"
+            '      FROM "patients"\n'
             "    ) AS patients\n"
             "    JOIN (\n"
             "      SELECT\n"
             "        *\n"
-            "      FROM diabetes\n"
+            '      FROM "diabetes"\n'
             "    ) AS diabetes\n"
             "      ON patients.id = diabetes.patient_id\n"
             "    JOIN (\n"
             "      SELECT\n"
             "        *\n"
-            "      FROM heart\n"
+            '      FROM "heart"\n'
             "    ) AS heart\n"
             "      ON patients.id = heart.patient_id\n"
             "  )\n"
@@ -480,32 +475,31 @@ FROM (
         view_query_builder.schema.columns[0].name = "column --"
         query = view_query_builder.build_query()
         assert (
-            query
-            == """SELECT
-  column___,
-  parents_name,
-  children_name
-FROM (
-  SELECT
-    column___ AS column___,
-    parents_name AS parents_name,
-    children_name AS children_name
-  FROM (
-    SELECT
-      column___ AS column___,
-      parents.name AS parents_name,
-      children.name AS children_name
-    FROM (
-      SELECT
-        *
-      FROM parents
-    ) AS parents
-    JOIN (
-      SELECT
-        *
-      FROM children
-    ) AS children
-      ON parents.id = children.id
-  )
-) AS parent_children"""
+            "SELECT\n"
+            '  "column___",\n'
+            '  "parents_name",\n'
+            '  "children_name"\n'
+            "FROM (\n"
+            "  SELECT\n"
+            '    "column___" AS "column___",\n'
+            '    "parents_name" AS "parents_name",\n'
+            '    "children_name" AS "children_name"\n'
+            "  FROM (\n"
+            "    SELECT\n"
+            '      "column___" AS "column___",\n'
+            '      "parents"."name" AS "parents_name",\n'
+            '      "children"."name" AS "children_name"\n'
+            "    FROM (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "parents"\n'
+            '    ) AS "parents"\n'
+            "    JOIN (\n"
+            "      SELECT\n"
+            "        *\n"
+            '      FROM "children"\n'
+            '    ) AS "children"\n'
+            '      ON "parents"."id" = "children"."id"\n'
+            "  )\n"
+            ') AS "parent_children"'
         )


### PR DESCRIPTION
- [x] Tests added and passed if fixing a bug or adding a new feature.
- [x] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Default quoting of SQL identifiers added to `BaseQueryBuilder` and `ViewQueryBuilder`, with tests updated to reflect this change.
> 
>   - **Behavior**:
>     - Default quoting of SQL identifiers using `quote_identifiers` in `BaseQueryBuilder` and `ViewQueryBuilder`.
>     - Affects `build_query()` and `get_head_query()` methods in both classes.
>   - **Tests**:
>     - Updated expected SQL strings in `test_sql_loader.py`, `test_group_by.py`, `test_query_builder.py`, `test_sql_transformation_manager.py`, and `test_view_query_builder.py` to include quoted identifiers.
>     - Ensures that all SQL queries are correctly formatted with quotes around identifiers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for c461eaa510cbac12f8f5c14e810902dd8dc1daa5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->