### PR TITLE
fix(sql_query): resolve double dash issue in url path

### DIFF
--- a/tests/unit_tests/data_loader/test_loader.py
+++ b/tests/unit_tests/data_loader/test_loader.py
@@ -112,3 +112,34 @@ class TestDatasetLoader:
         loader = LocalDatasetLoader(sample_schema, "test/test")
         with pytest.raises(RuntimeError):
             loader.execute_query("SELECT * FROM nonexistent_table")
+
+    def test_read_parquet_file(self, sample_schema):
+        loader = LocalDatasetLoader(sample_schema, "test/test")
+        with pytest.raises(RuntimeError):
+            loader.execute_query(
+                """SELECT
+            "*",
+            FROM READ_PARQUET(
+            'http://127.0.0.1:54321/storage/v1/object/sign/datasets/pai-personal-32771/spf-base/data.parquet?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJkYXRhc2V0cy9wYWktcGVyc29uYWwtMzI3NzEvaGEzMDIwZS1jbGktc3BmLWJhc2UvZGF0YS5wYXJxdWV0IiwiaWF0IjoxNzQxODcwMTI3LCJleHAiOjE3NDE4NzAxNTd9.pzCL4efZJbZiAXzzbjFEiI--a3WAwECYzKhMwF3r5vE'
+            )"""
+            )
+
+    def test_read_parquet_file_with_mock_query_validator(self, sample_schema):
+        with patch("os.path.exists", return_value=True), patch(
+            "pandasai.data_loader.local_loader.is_sql_query_safe"
+        ) as mock_is_query_safe:
+            loader = LocalDatasetLoader(sample_schema, "test/test")
+            with pytest.raises(RuntimeError):
+                loader.execute_query(
+                    """SELECT
+                "*",
+                FROM READ_PARQUET(
+                'http://127.0.0.1:54321/storage/v1/object/sign/datasets/pai-personal-32771/spf-base/data.parquet?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJkYXRhc2V0cy9wYWktcGVyc29uYWwtMzI3NzEvaGEzMDIwZS1jbGktc3BmLWJhc2UvZGF0YS5wYXJxdWV0IiwiaWF0IjoxNzQxODcwMTI3LCJleHAiOjE3NDE4NzAxNTd9.pzCL4efZJbZiAXzzbjFEiI--a3WAwECYzKhMwF3r5vE'
+                )"""
+                )
+
+                mock_is_query_safe.assert_called_once_with(
+                    """SELECT
+                "*",
+                FROM dummy_table"""
+                )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add method to replace `READ_PARQUET` blocks with a dummy table for SQL validation in `LocalDatasetLoader` and update tests accordingly.
> 
>   - **Behavior**:
>     - Add `_replace_readparquet_block_with_table()` in `LocalDatasetLoader` to replace `READ_PARQUET` blocks with `dummy_table` for SQL validation.
>     - Modify `execute_query()` in `LocalDatasetLoader` to use the new method for query validation.
>   - **Tests**:
>     - Add `test_read_parquet_file` and `test_read_parquet_file_with_mock_query_validator` in `test_loader.py` to test `READ_PARQUET` block replacement and query validation.
>     - Ensure `mock_is_query_safe` is called with the modified query in `test_read_parquet_file_with_mock_query_validator`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 5ad945ff2123bc0dfd19b405b62ca56df6cee5f2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->