### PR TITLE
fix(dataframe_serialize): truncate content of dataframe columns

### DIFF
--- a/pandasai/helpers/dataframe_serializer.py
+++ b/pandasai/helpers/dataframe_serializer.py
@@ -11,7 +11,7 @@ class DataframeSerializer:
     @classmethod
     def serialize(cls, df: "DataFrame", dialect: str = "postgres") -> str:
         """
-        Convert df to a CSV-like format wrapped inside <table> tags, truncating long text values.
+        Convert df to a CSV-like format wrapped inside <table> tags, truncating long text values, and serializing only a subset of rows using df.head().
 
         Args:
             df (pd.DataFrame): Pandas DataFrame

--- a/pandasai/helpers/dataframe_serializer.py
+++ b/pandasai/helpers/dataframe_serializer.py
@@ -22,20 +22,19 @@ class DataframeSerializer:
         """
 
         # Start building the table metadata
-        dataframe_info = f'<table dialect="{dialect}" table_name="{getattr(df.schema, "name", "unknown")}"'
+        dataframe_info = f'<table dialect="{dialect}" table_name="{df.schema.name}"'
 
         # Add description attribute if available
-        description = getattr(df.schema, "description", None)
-        if description:
-            dataframe_info += f' description="{description}"'
+        if df.schema.description is not None:
+            dataframe_info += f' description="{df.schema.description}"'
 
-        dataframe_info += f' dimensions="{getattr(df, "rows_count", len(df))}x{getattr(df, "columns_count", len(df.columns))}">\n'
+        dataframe_info += f' dimensions="{df.rows_count}x{df.columns_count}">'
 
         # Truncate long values
         df_truncated = cls._truncate_dataframe(df.head())
 
         # Convert to CSV format
-        dataframe_info += df_truncated.to_csv(index=False)
+        dataframe_info += f"\n{df_truncated.to_csv(index=False)}"
 
         # Close the table tag
         dataframe_info += "</table>\n"
@@ -51,7 +50,7 @@ class DataframeSerializer:
                 value = json.dumps(value, ensure_ascii=False)
 
             if isinstance(value, str) and len(value) > cls.MAX_COLUMN_TEXT_LENGTH:
-                return f"{value[: cls.MAX_COLUMN_TEXT_LENGTH]} …"
+                return f"{value[: cls.MAX_COLUMN_TEXT_LENGTH]}…"
             return value
 
         return df.applymap(truncate_value)

--- a/tests/unit_tests/helpers/test_dataframe_serializer.py
+++ b/tests/unit_tests/helpers/test_dataframe_serializer.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from pandasai.helpers.dataframe_serializer import DataframeSerializer
 
 
@@ -26,4 +28,29 @@ A,B
 3,6
 </table>
 """
+        assert result.replace("\r\n", "\n") == expected.replace("\r\n", "\n")
+
+    def test_serialize_with_dataframe_long_strings(self, sample_df):
+        """Test serialization with long strings to ensure truncation."""
+
+        # Generate a DataFrame with a long string in column 'A'
+        long_text = "A" * 300
+        sample_df.loc[0, "A"] = long_text
+
+        # Serialize the DataFrame
+        result = DataframeSerializer.serialize(sample_df, dialect="mysql")
+
+        # Expected truncated value (200 characters + ellipsis)
+        truncated_text = long_text[: DataframeSerializer.MAX_COLUMN_TEXT_LENGTH] + "…"
+
+        # Expected output
+        expected = f"""<table dialect="mysql" table_name="table_6c30b42101939c7bdf95f4c1052d615c" dimensions="3x2">
+A,B
+{truncated_text},4
+2,5
+3,6
+</table>
+"""
+
+        # Normalize line endings before asserting
         assert result.replace("\r\n", "\n") == expected.replace("\r\n", "\n")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `DataframeSerializer` now truncates DataFrame text values exceeding 200 characters during serialization, with new tests verifying this behavior.
> 
>   - **Behavior**:
>     - `DataframeSerializer.serialize()` now truncates text values exceeding 200 characters with an ellipsis.
>     - Handles JSON-like objects by converting them to strings before truncation.
>   - **Implementation**:
>     - Added `MAX_COLUMN_TEXT_LENGTH` constant to `DataframeSerializer`.
>     - Introduced `_truncate_dataframe()` method to handle truncation logic.
>   - **Testing**:
>     - Added `test_serialize_with_dataframe_long_strings()` in `test_dataframe_serializer.py` to verify truncation behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for ebd422e40769fa07551e48bdc613133495b0853d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->