### PR TITLE
fix(view_loader): avoid lower casing the column name

### DIFF
--- a/pandasai/helpers/sql_sanitizer.py
+++ b/pandasai/helpers/sql_sanitizer.py
@@ -2,10 +2,18 @@ import os
 import re
 
 import sqlglot
+from sqlglot import parse_one
+from sqlglot.optimizer.qualify_columns import quote_identifiers
 
 
 def sanitize_view_column_name(relation_name: str) -> str:
-    return ".".join(list(map(sanitize_sql_table_name, relation_name.split("."))))
+    return (
+        parse_one(
+            ".".join(list(map(sanitize_sql_table_name, relation_name.split("."))))
+        )
+        .transform(quote_identifiers)
+        .sql()
+    )
 
 
 def sanitize_sql_table_name(table_name: str) -> str:

--- a/pandasai/query_builders/view_query_builder.py
+++ b/pandasai/query_builders/view_query_builder.py
@@ -24,13 +24,12 @@ class ViewQueryBuilder(BaseQueryBuilder):
 
     @staticmethod
     def normalize_view_column_name(name: str) -> str:
-        return normalize_identifiers(parse_one(sanitize_view_column_name(name))).sql()
+        return sanitize_view_column_name(name)
 
     @staticmethod
     def normalize_view_column_alias(name: str) -> str:
-        return normalize_identifiers(
-            sanitize_view_column_name(name).replace(".", "_")
-        ).sql()
+        col_name = name.replace(".", "_")
+        return sanitize_view_column_name(col_name)
 
     def _get_group_by_columns(self) -> list[str]:
         """Get the group by columns with proper view column aliasing."""

--- a/tests/unit_tests/helpers/test_sql_sanitizer.py
+++ b/tests/unit_tests/helpers/test_sql_sanitizer.py
@@ -25,7 +25,7 @@ class TestSqlSanitizer:
 
     def test_sanitize_relation_name_valid(self):
         relation = "dataset-name.column"
-        expected = "dataset_name.column"
+        expected = '"dataset_name"."column"'
         assert sanitize_view_column_name(relation) == expected
 
     def test_safe_select_query(self):

--- a/tests/unit_tests/query_builders/test_view_query_builder.py
+++ b/tests/unit_tests/query_builders/test_view_query_builder.py
@@ -178,7 +178,6 @@ class TestViewQueryBuilder:
     def test_column_name_injection(self, view_query_builder):
         view_query_builder.schema.columns[0].name = "column; DROP TABLE users;"
         query = view_query_builder.build_query()
-        print(query)
         assert query == (
             """SELECT
   "column__DROP_TABLE_users_",
@@ -247,7 +246,6 @@ FROM (
             0
         ].name = "column UNION SELECT username, password FROM users;"
         query = view_query_builder.build_query()
-        print(query)
         assert query == (
             """SELECT
   "column_UNION_SELECT_username__password_FROM_users_",

--- a/tests/unit_tests/query_builders/test_view_query_builder.py
+++ b/tests/unit_tests/query_builders/test_view_query_builder.py
@@ -104,41 +104,42 @@ class TestViewQueryBuilder:
 
     def test_get_columns(self, view_query_builder):
         assert view_query_builder._get_columns() == [
-            "parents_id AS parents_id",
-            "parents_name AS parents_name",
-            "children_name AS children_name",
+            '"parents_id" AS "parents_id"',
+            '"parents_name" AS "parents_name"',
+            '"children_name" AS "children_name"',
         ]
 
     def test_get__group_by_columns(self, view_query_builder):
         view_query_builder.schema.group_by = ["parents.id"]
         group_by_column = view_query_builder._get_group_by_columns()
-        assert group_by_column == ["parents_id"]
+        assert group_by_column == ['"parents_id"']
 
     def test_get_table_expression(self, view_query_builder):
+        print(view_query_builder._get_table_expression())
         assert view_query_builder._get_table_expression() == (
-            "(\n"
-            "  SELECT\n"
-            "    parents_id AS parents_id,\n"
-            "    parents_name AS parents_name,\n"
-            "    children_name AS children_name\n"
-            "  FROM (\n"
-            "    SELECT\n"
-            "      parents.id AS parents_id,\n"
-            "      parents.name AS parents_name,\n"
-            "      children.name AS children_name\n"
-            "    FROM (\n"
-            "      SELECT\n"
-            "        *\n"
-            '      FROM "parents"\n'
-            "    ) AS parents\n"
-            "    JOIN (\n"
-            "      SELECT\n"
-            "        *\n"
-            '      FROM "children"\n'
-            "    ) AS children\n"
-            "      ON parents.id = children.id\n"
-            "  )\n"
-            ") AS parent_children"
+            """(
+  SELECT
+    "parents_id" AS "parents_id",
+    "parents_name" AS "parents_name",
+    "children_name" AS "children_name"
+  FROM (
+    SELECT
+      "parents"."id" AS "parents_id",
+      "parents"."name" AS "parents_name",
+      "children"."name" AS "children_name"
+    FROM (
+      SELECT
+        *
+      FROM "parents"
+    ) AS parents
+    JOIN (
+      SELECT
+        *
+      FROM "children"
+    ) AS children
+      ON "parents"."id" = "children"."id"
+  )
+) AS parent_children"""
         )
 
     def test_table_name_injection(self, view_query_builder):
@@ -177,34 +178,35 @@ class TestViewQueryBuilder:
     def test_column_name_injection(self, view_query_builder):
         view_query_builder.schema.columns[0].name = "column; DROP TABLE users;"
         query = view_query_builder.build_query()
+        print(query)
         assert query == (
-            "SELECT\n"
-            '  "column__drop_table_users_",\n'
-            '  "parents_name",\n'
-            '  "children_name"\n'
-            "FROM (\n"
-            "  SELECT\n"
-            '    "column__drop_table_users_" AS "column__drop_table_users_",\n'
-            '    "parents_name" AS "parents_name",\n'
-            '    "children_name" AS "children_name"\n'
-            "  FROM (\n"
-            "    SELECT\n"
-            '      "column__drop_table_users_" AS "column__drop_table_users_",\n'
-            '      "parents"."name" AS "parents_name",\n'
-            '      "children"."name" AS "children_name"\n'
-            "    FROM (\n"
-            "      SELECT\n"
-            "        *\n"
-            '      FROM "parents"\n'
-            '    ) AS "parents"\n'
-            "    JOIN (\n"
-            "      SELECT\n"
-            "        *\n"
-            '      FROM "children"\n'
-            '    ) AS "children"\n'
-            '      ON "parents"."id" = "children"."id"\n'
-            "  )\n"
-            ') AS "parent_children"'
+            """SELECT
+  "column__DROP_TABLE_users_",
+  "parents_name",
+  "children_name"
+FROM (
+  SELECT
+    "column__DROP_TABLE_users_" AS "column__DROP_TABLE_users_",
+    "parents_name" AS "parents_name",
+    "children_name" AS "children_name"
+  FROM (
+    SELECT
+      "column__DROP_TABLE_users_" AS "column__DROP_TABLE_users_",
+      "parents"."name" AS "parents_name",
+      "children"."name" AS "children_name"
+    FROM (
+      SELECT
+        *
+      FROM "parents"
+    ) AS "parents"
+    JOIN (
+      SELECT
+        *
+      FROM "children"
+    ) AS "children"
+      ON "parents"."id" = "children"."id"
+  )
+) AS \"parent_children\""""
         )
 
     def test_table_name_union_injection(self, view_query_builder):
@@ -245,36 +247,35 @@ class TestViewQueryBuilder:
             0
         ].name = "column UNION SELECT username, password FROM users;"
         query = view_query_builder.build_query()
+        print(query)
         assert query == (
-            "SELECT\n"
-            '  "column_union_select_username__password_from_users_",\n'
-            '  "parents_name",\n'
-            '  "children_name"\n'
-            "FROM (\n"
-            "  SELECT\n"
-            '    "column_union_select_username__password_from_users_" AS '
-            '"column_union_select_username__password_from_users_",\n'
-            '    "parents_name" AS "parents_name",\n'
-            '    "children_name" AS "children_name"\n'
-            "  FROM (\n"
-            "    SELECT\n"
-            '      "column_union_select_username__password_from_users_" AS '
-            '"column_union_select_username__password_from_users_",\n'
-            '      "parents"."name" AS "parents_name",\n'
-            '      "children"."name" AS "children_name"\n'
-            "    FROM (\n"
-            "      SELECT\n"
-            "        *\n"
-            '      FROM "parents"\n'
-            '    ) AS "parents"\n'
-            "    JOIN (\n"
-            "      SELECT\n"
-            "        *\n"
-            '      FROM "children"\n'
-            '    ) AS "children"\n'
-            '      ON "parents"."id" = "children"."id"\n'
-            "  )\n"
-            ') AS "parent_children"'
+            """SELECT
+  "column_UNION_SELECT_username__password_FROM_users_",
+  "parents_name",
+  "children_name"
+FROM (
+  SELECT
+    "column_UNION_SELECT_username__password_FROM_users_" AS "column_UNION_SELECT_username__password_FROM_users_",
+    "parents_name" AS "parents_name",
+    "children_name" AS "children_name"
+  FROM (
+    SELECT
+      "column_UNION_SELECT_username__password_FROM_users_" AS "column_UNION_SELECT_username__password_FROM_users_",
+      "parents"."name" AS "parents_name",
+      "children"."name" AS "children_name"
+    FROM (
+      SELECT
+        *
+      FROM "parents"
+    ) AS "parents"
+    JOIN (
+      SELECT
+        *
+      FROM "children"
+    ) AS "children"
+      ON "parents"."id" = "children"."id"
+  )
+) AS \"parent_children\""""
         )
 
     def test_table_name_comment_injection(self, view_query_builder):
@@ -333,33 +334,35 @@ class TestViewQueryBuilder:
         }
         query_builder = ViewQueryBuilder(schema, dependencies)
 
+        print(query_builder._get_table_expression())
+
         assert query_builder._get_table_expression() == (
-            "(\n"
-            "  SELECT\n"
-            "    diabetes_age AS diabetes_age,\n"
-            "    diabetes_bloodpressure AS diabetes_bloodpressure,\n"
-            "    heart_age AS heart_age,\n"
-            "    heart_restingbp AS heart_restingbp\n"
-            "  FROM (\n"
-            "    SELECT\n"
-            "      diabetes.age AS diabetes_age,\n"
-            "      diabetes.bloodpressure AS diabetes_bloodpressure,\n"
-            "      heart.age AS heart_age,\n"
-            "      heart.restingbp AS heart_restingbp\n"
-            "    FROM (\n"
-            "      SELECT\n"
-            "        *\n"
-            '      FROM "diabetes"\n'
-            "    ) AS diabetes\n"
-            "    JOIN (\n"
-            "      SELECT\n"
-            "        *\n"
-            '      FROM "heart"\n'
-            "    ) AS heart\n"
-            "      ON diabetes.age = heart.age AND diabetes.bloodpressure = "
-            "heart.restingbp\n"
-            "  )\n"
-            ") AS health_combined"
+            """(
+  SELECT
+    "diabetes_age" AS "diabetes_age",
+    "diabetes_bloodpressure" AS "diabetes_bloodpressure",
+    "heart_age" AS "heart_age",
+    "heart_restingbp" AS "heart_restingbp"
+  FROM (
+    SELECT
+      "diabetes"."age" AS "diabetes_age",
+      "diabetes"."bloodpressure" AS "diabetes_bloodpressure",
+      "heart"."age" AS "heart_age",
+      "heart"."restingbp" AS "heart_restingbp"
+    FROM (
+      SELECT
+        *
+      FROM "diabetes"
+    ) AS diabetes
+    JOIN (
+      SELECT
+        *
+      FROM "heart"
+    ) AS heart
+      ON "diabetes"."age" = "heart"."age"
+      AND "diabetes"."bloodpressure" = "heart"."restingbp"
+  )
+) AS health_combined"""
         )
 
     def test_multiple_joins_same_table_with_aliases(self):
@@ -387,33 +390,35 @@ class TestViewQueryBuilder:
         }
         query_builder = ViewQueryBuilder(schema, dependencies)
 
+        print(query_builder._get_table_expression())
+
         assert query_builder._get_table_expression() == (
-            "(\n"
-            "  SELECT\n"
-            "    diabetes_age AS diabetes_age,\n"
-            "    diabetes_bloodpressure AS pressure,\n"
-            "    heart_age AS heart_age,\n"
-            "    heart_restingbp AS heart_restingbp\n"
-            "  FROM (\n"
-            "    SELECT\n"
-            "      diabetes.age AS diabetes_age,\n"
-            "      diabetes.bloodpressure AS diabetes_bloodpressure,\n"
-            "      heart.age AS heart_age,\n"
-            "      heart.restingbp AS heart_restingbp\n"
-            "    FROM (\n"
-            "      SELECT\n"
-            "        *\n"
-            '      FROM "diabetes"\n'
-            "    ) AS diabetes\n"
-            "    JOIN (\n"
-            "      SELECT\n"
-            "        *\n"
-            '      FROM "heart"\n'
-            "    ) AS heart\n"
-            "      ON diabetes.age = heart.age AND diabetes.bloodpressure = "
-            "heart.restingbp\n"
-            "  )\n"
-            ") AS health_combined"
+            """(
+  SELECT
+    "diabetes_age" AS "diabetes_age",
+    "diabetes_bloodpressure" AS pressure,
+    "heart_age" AS "heart_age",
+    "heart_restingbp" AS "heart_restingbp"
+  FROM (
+    SELECT
+      "diabetes"."age" AS "diabetes_age",
+      "diabetes"."bloodpressure" AS "diabetes_bloodpressure",
+      "heart"."age" AS "heart_age",
+      "heart"."restingbp" AS "heart_restingbp"
+    FROM (
+      SELECT
+        *
+      FROM "diabetes"
+    ) AS diabetes
+    JOIN (
+      SELECT
+        *
+      FROM "heart"
+    ) AS heart
+      ON "diabetes"."age" = "heart"."age"
+      AND "diabetes"."bloodpressure" = "heart"."restingbp"
+  )
+) AS health_combined"""
         )
 
     def test_three_table_join(self, mysql_view_dependencies_dict):
@@ -442,14 +447,14 @@ class TestViewQueryBuilder:
         assert query_builder._get_table_expression() == (
             "(\n"
             "  SELECT\n"
-            "    patients_id AS patients_id,\n"
-            "    diabetes_glucose AS diabetes_glucose,\n"
-            "    heart_cholesterol AS heart_cholesterol\n"
+            '    "patients_id" AS "patients_id",\n'
+            '    "diabetes_glucose" AS "diabetes_glucose",\n'
+            '    "heart_cholesterol" AS "heart_cholesterol"\n'
             "  FROM (\n"
             "    SELECT\n"
-            "      patients.id AS patients_id,\n"
-            "      diabetes.glucose AS diabetes_glucose,\n"
-            "      heart.cholesterol AS heart_cholesterol\n"
+            '      "patients"."id" AS "patients_id",\n'
+            '      "diabetes"."glucose" AS "diabetes_glucose",\n'
+            '      "heart"."cholesterol" AS "heart_cholesterol"\n'
             "    FROM (\n"
             "      SELECT\n"
             "        *\n"
@@ -460,13 +465,13 @@ class TestViewQueryBuilder:
             "        *\n"
             '      FROM "diabetes"\n'
             "    ) AS diabetes\n"
-            "      ON patients.id = diabetes.patient_id\n"
+            '      ON "patients"."id" = "diabetes"."patient_id"\n'
             "    JOIN (\n"
             "      SELECT\n"
             "        *\n"
             '      FROM "heart"\n'
             "    ) AS heart\n"
-            "      ON patients.id = heart.patient_id\n"
+            '      ON "patients"."id" = "heart"."patient_id"\n'
             "  )\n"
             ") AS patient_records"
         )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Avoid lowercasing column names in SQL queries by using `quote_identifiers` in `sanitize_view_column_name`.
> 
>   - **Behavior**:
>     - `sanitize_view_column_name` in `sql_sanitizer.py` now uses `quote_identifiers` to avoid lowercasing column names.
>     - `normalize_view_column_name` and `normalize_view_column_alias` in `ViewQueryBuilder` updated to use `sanitize_view_column_name` directly.
>   - **Tests**:
>     - Updated expected results in `test_sql_sanitizer.py` and `test_view_query_builder.py` to reflect quoted column names.
>     - Added tests for SQL injection scenarios in `test_view_query_builder.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 38bdf969d1cb89bcf4e09fba9ecc206fb185fd06. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->