### PR TITLE
Fix: Resolve Python 3.8 Compatibility Issue in semantic_layer_schema.py

### DIFF
--- a/pandasai/data_loader/semantic_layer_schema.py
+++ b/pandasai/data_loader/semantic_layer_schema.py
@@ -391,7 +391,7 @@ class SemanticLayerSchema(BaseModel):
             )
         return self
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         return self.model_dump(exclude_none=True, by_alias=True)
 
     def to_yaml(self) -> str:


### PR DESCRIPTION
- [ ] Closes #1690  

This pull request addresses a `TypeError: 'type' object is not subscriptable` error encountered when using PandasAI with Python 3.8. The error originates from the `to_dict` method in `pandasai/data_loader/semantic_layer_schema.py`, where the type hint `dict[str, Any]` is used. This syntax is only valid in Python 3.9 and later, contradicting the project's stated support for Python 3.8+.

As reported in issue #1690 , the documentation states Python 3.8+ compatibility, which is not currently the case.

**Solution:**

The solution is to replace `dict[str, Any]` with `Dict[str, Any]` from the `typing` module. This ensures compatibility with Python 3.8 and aligns with the project's documentation.

**Changes:**

- Modified `pandasai/data_loader/semantic_layer_schema.py` to use `Dict[str, Any]` in the `to_dict` method's type hint.

**Test Cases (Conceptual - Adaptable to GitHub Editor):**

**Test Case 1: Basic Dictionary Output**

- **Objective:** Verify that `to_dict` returns a dictionary.
- **Steps:**
  1. Create a `SemanticLayerSchema` instance.
  2. Call the `to_dict` method on the instance.
  3. Assert that the return value is a dictionary.

**Test Case 2: Dictionary Structure Validation**

- **Objective:** Verify that the dictionary returned by `to_dict` has the correct keys and structure.
- **Steps:**
  1. Create a `SemanticLayerSchema` instance with sample data.
  2. Call `to_dict`.
  3. Assert that the returned dictionary has the expected keys (e.g., 'name', 'source', 'columns').
  4. Assert that the values within the dictionary have the expected types.

**Key Considerations:**

- The essential change is the replacement of `dict[str, Any]` with `Dict[str, Any]` within the `to_dict` method's type hint.
- This adjustment specifically addresses a `TypeError` that arises in Python 3.8 environments due to the incompatibility of the original type hinting syntax.
- I have only focused on the code correction and a clearly articulated description.
- you can check the test cases and ensure if they verify the function's dictionary return rather than directly testing the type hinting.
- This fix brings the code into alignment with the project's documentation, which indicates Python 3.8+ compatibility.

This fix ensures that PandasAI remains compatible with Python 3.8, as stated in the project's documentation. This prevents users on Python 3.8 from encountering the `TypeError` and maintains a consistent user experience across supported Python versions.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Python 3.8 compatibility issue in `semantic_layer_schema.py` by replacing `dict[str, Any]` with `Dict[str, Any]` in `to_dict()` method.
> 
>   - **Compatibility Fix**:
>     - Replaces `dict[str, Any]` with `Dict[str, Any]` in `to_dict()` method in `semantic_layer_schema.py` to ensure Python 3.8 compatibility.
>   - **Issue Addressed**:
>     - Fixes `TypeError: 'type' object is not subscriptable` in Python 3.8 environments.
>   - **Documentation Alignment**:
>     - Aligns code with documentation stating support for Python 3.8+.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 3208351945dea9c71e0a36725ba73a480e2ce02c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->