### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@
 [![Downloads](https://static.pepy.tech/badge/pandasai)](https://pepy.tech/project/pandasai) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1ZnO-njhL7TBOYPZaqvMvGtsjckZKrv2E?usp=sharing)
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/sinaptik-ai/pandas-ai?lang=de) | 
+[Español](https://www.readme-i18n.com/sinaptik-ai/pandas-ai?lang=es) | 
+[français](https://www.readme-i18n.com/sinaptik-ai/pandas-ai?lang=fr) | 
+[日本語](https://www.readme-i18n.com/sinaptik-ai/pandas-ai?lang=ja) | 
+[한국어](https://www.readme-i18n.com/sinaptik-ai/pandas-ai?lang=ko) | 
+[Português](https://www.readme-i18n.com/sinaptik-ai/pandas-ai?lang=pt) | 
+[Русский](https://www.readme-i18n.com/sinaptik-ai/pandas-ai?lang=ru) | 
+[中文](https://www.readme-i18n.com/sinaptik-ai/pandas-ai?lang=zh)
+
 PandasAI is a Python platform that makes it easy to ask questions to your data in natural language. It helps non-technical users to interact with their data in a more natural way, and it helps technical users to save time, and effort when working with data.
 
 # 🔧 Getting started


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

The updated links can be previewed in my forked repository: https://github.com/dowithless/pandas-ai/tree/patch-1

- [ ] Closes #xxxx (Replace xxxx with the GitHub issue number).
- [ ] Tests added and passed if fixing a bug or adding a new feature.
- [ ] All [code checks passed](https://github.com/gventuri/pandas-ai/blob/main/CONTRIBUTING.md#-testing).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add language selection links to `README.md` for multiple translated versions.
> 
>   - **Documentation**:
>     - Added language selection links to `README.md` for German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese versions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for 6d5665d8724f6cc0388030acae3c1d016195580d. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->