### PR TITLE
Fix last_code_generated retrieval logic in multi-turn conversations

### DIFF
--- a/pandasai/core/code_generation/base.py
+++ b/pandasai/core/code_generation/base.py
@@ -35,7 +35,12 @@ class CodeGenerator:
             self._context.last_code_generated = code
             self._context.logger.log(f"Code Generated:\n{code}")
 
-            return self.validate_and_clean_code(code)
+            # Validate and clean the code
+            cleaned_code = self.validate_and_clean_code(code)
+            # Update last_code_generated with the cleaned code
+            self._context.last_code_generated = cleaned_code
+
+            return cleaned_code
 
         except Exception as e:
             error_message = f"An error occurred during code generation: {e}"

--- a/pandasai/core/prompts/__init__.py
+++ b/pandasai/core/prompts/__init__.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 def get_chat_prompt_for_sql(context: AgentState) -> BasePrompt:
     return GeneratePythonCodeWithSQLPrompt(
         context=context,
-        last_code_generated=context.get("last_code_generated"),
+        last_code_generated=context.last_code_generated,
         output_type=context.output_type,
     )
 

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -542,3 +542,25 @@ class TestAgent:
         # Verify the error was logged
         mock_logger.log.assert_called_once()
         assert "Processing failed with error" in mock_logger.log.call_args[0][0]
+
+    def test_last_code_generated_retrieval(self, agent: Agent):
+        """Test that last_code_generated is correctly retrieved in get_chat_prompt_for_sql."""
+        # 设置 last_code_generated
+        test_code = "print('Test code')"
+        agent._state.last_code_generated = test_code
+
+        # 使用 get_chat_prompt_for_sql 获取提示
+        from pandasai.core.prompts import get_chat_prompt_for_sql
+
+        prompt = get_chat_prompt_for_sql(agent._state)
+
+        # 验证提示中使用了正确的 last_code_generated
+        assert prompt.props["last_code_generated"] == test_code
+
+        # 验证不是从 intermediate_values 中获取的
+        agent._state.add("last_code_generated", "Wrong code")
+        prompt = get_chat_prompt_for_sql(agent._state)
+
+        # 应该仍然使用 last_code_generated 属性，而不是 intermediate_values 中的值
+        assert prompt.props["last_code_generated"] == test_code
+        assert prompt.props["last_code_generated"] != "Wrong code"


### PR DESCRIPTION
# Fix last_code_generated retrieval logic in multi-turn conversations

## Issue Description

In multi-turn conversations, previously generated code was not being correctly passed to new code generation processes, causing a lack of continuity in code generation. This issue affected the user experience when conducting multi-step analyses that required building upon previous code.

## Root Cause

The issue stemmed from a mismatch in how `last_code_generated` was stored and retrieved:

1. The generated code was stored in the `AgentState.last_code_generated` attribute:
   ```python
   self._context.last_code_generated = code
   ```

2. However, when creating a new prompt, the code attempted to retrieve it from the `intermediate_values` dictionary:
   ```python
   # In get_chat_prompt_for_sql function
   last_code_generated=context.get("last_code_generated")
   ```

3. The `AgentState.get` method only fetches values from the `intermediate_values` dictionary:
   ```python
   def get(self, key: str, default: Any = "") -> Any:
       """Fetches a value from intermediate values or returns a default."""
       return self.intermediate_values.get(key, default)
   ```

This disconnect meant that in multi-turn conversations, each new code generation would start from scratch rather than building upon previous code.

## Changes Made

This PR fixes the issue by:

1. Modifying `get_chat_prompt_for_sql` to directly use the `last_code_generated` attribute:
   ```python
   # Changed from:
   last_code_generated=context.get("last_code_generated")
   
   # To:
   last_code_generated=context.last_code_generated
   ```

2. Ensuring the cleaned code is also stored in `last_code_generated`:
   ```python
   # Changed from:
   return self.validate_and_clean_code(code)
   
   # To:
   cleaned_code = self.validate_and_clean_code(code)
   self._context.last_code_generated = cleaned_code
   return cleaned_code
   ```

3. Adding a test case to verify the fix:
   ```python
   def test_last_code_generated_retrieval(self, agent: Agent):
       """Test that last_code_generated is correctly retrieved in get_chat_prompt_for_sql."""
       # Set last_code_generated
       test_code = "print('Test code')"
       agent._state.last_code_generated = test_code
       
       # Get prompt using get_chat_prompt_for_sql
       from pandasai.core.prompts import get_chat_prompt_for_sql
       prompt = get_chat_prompt_for_sql(agent._state)
       
       # Verify prompt uses correct last_code_generated
       assert prompt.props["last_code_generated"] == test_code
       
       # Verify it's not retrieved from intermediate_values
       agent._state.add("last_code_generated", "Wrong code")
       prompt = get_chat_prompt_for_sql(agent._state)
       
       # Should still use last_code_generated attribute, not intermediate_values
       assert prompt.props["last_code_generated"] == test_code
       assert prompt.props["last_code_generated"] != "Wrong code"
   ```

## Benefits

This fix ensures:

1. Code continuity in multi-turn conversations
2. Better user experience when building complex analyses step by step
3. More efficient code generation by leveraging previously generated code

## Testing

A new test case `test_last_code_generated_retrieval` was added to verify the fix, which passes successfully. 
