### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ make format
 
 ### Spell check
 
-We usee `codespell` to check the spelling of our code. You can run codespell by running the following command:
+We use `codespell` to check the spelling of our code. You can run codespell by running the following command:
 
 ```bash
 make spell_fix


### PR DESCRIPTION
## Summary
Fix typo in the spell check section of CONTRIBUTING.md where "We usee" should be "We use".

## Changes
- Corrected "We usee `codespell`" to "We use `codespell`" in line 56

This is a minor documentation fix that improves readability and corrects a spelling error in the contributing guidelines.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `CONTRIBUTING.md` by correcting "usee" to "use" in the spell check section.
> 
>   - **Documentation**:
>     - Fix typo in `CONTRIBUTING.md`, changing "We usee `codespell`" to "We use `codespell`" in the spell check section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sinaptik-ai%2Fpandas-ai&utm_source=github&utm_medium=referral)<sup> for facda81246fe8167fbf50eb64ef1d4a22799d7f5. You can [customize](https://app.ellipsis.dev/sinaptik-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->