### PR TITLE
fix: restore LocalLLM for OpenAI-compatible local servers (fixes #1888)

### DIFF
--- a/pandasai/llm/local_llm.py
+++ b/pandasai/llm/local_llm.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from openai import OpenAI
+
+from pandasai.core.prompts.base import BasePrompt
+from pandasai.llm.base import LLM
+
+if TYPE_CHECKING:
+    from pandasai.agent.state import AgentState
+
+
+class LocalLLM(LLM):
+    """LLM wrapper for OpenAI-compatible local servers (Ollama, LM Studio, etc.).
+
+    Connects to any server that exposes an OpenAI-compatible ``/v1`` endpoint,
+    such as `Ollama <https://ollama.com/>`_ or
+    `LM Studio <https://lmstudio.ai/>`_.
+
+    Args:
+        api_base (str): Base URL of the local server, e.g.
+            ``"http://localhost:11434/v1"`` for Ollama.
+        model (str): Model name to request from the server.
+        api_key (str): API key.  Most local servers accept any non-empty
+            string; defaults to ``"dummy"`` when omitted.
+        **kwargs: Extra keyword arguments forwarded to every
+            ``chat.completions.create`` call (e.g. ``temperature``,
+            ``max_tokens``).
+
+    Example::
+
+        from pandasai.llm.local_llm import LocalLLM
+
+        # Ollama
+        ollama_llm = LocalLLM(api_base="http://localhost:11434/v1", model="codellama")
+
+        # LM Studio
+        lm_studio_llm = LocalLLM(api_base="http://localhost:1234/v1")
+    """
+
+    def __init__(
+        self, api_base: str, model: str = "", api_key: str = "", **kwargs
+    ) -> None:
+        if not api_key:
+            api_key = "dummy"
+        super().__init__(api_key=api_key)
+        self.model = model
+        self._client = OpenAI(base_url=api_base, api_key=api_key).chat.completions
+        self._invocation_params = kwargs
+
+    @property
+    def type(self) -> str:
+        return "local"
+
+    def call(self, instruction: BasePrompt, context: AgentState = None) -> str:
+        memory = context.memory if context else None
+        self.last_prompt = self.prepend_system_prompt(instruction.to_string(), memory)
+
+        response = self._client.create(
+            model=self.model,
+            messages=[{"role": "user", "content": self.last_prompt}],
+            **self._invocation_params,
+        )
+        return response.choices[0].message.content

--- a/tests/unit_tests/llms/test_local_llm.py
+++ b/tests/unit_tests/llms/test_local_llm.py
@@ -1,0 +1,69 @@
+"""Unit tests for LocalLLM"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pandasai.llm.local_llm import LocalLLM
+
+
+@pytest.fixture
+def mock_openai():
+    with patch("pandasai.llm.local_llm.OpenAI") as mock_cls:
+        mock_completions = MagicMock()
+        mock_cls.return_value.chat.completions = mock_completions
+        yield mock_completions
+
+
+class TestLocalLLM:
+    def test_type(self, mock_openai):
+        llm = LocalLLM(api_base="http://localhost:11434/v1", model="codellama")
+        assert llm.type == "local"
+
+    def test_default_dummy_api_key(self, mock_openai):
+        with patch("pandasai.llm.local_llm.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions = MagicMock()
+            LocalLLM(api_base="http://localhost:11434/v1", model="codellama")
+            _, kwargs = mock_cls.call_args
+            assert kwargs["api_key"] == "dummy"
+
+    def test_custom_api_key(self, mock_openai):
+        with patch("pandasai.llm.local_llm.OpenAI") as mock_cls:
+            mock_cls.return_value.chat.completions = MagicMock()
+            LocalLLM(
+                api_base="http://localhost:11434/v1",
+                model="codellama",
+                api_key="mykey",
+            )
+            _, kwargs = mock_cls.call_args
+            assert kwargs["api_key"] == "mykey"
+
+    def test_call_returns_content(self, mock_openai):
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = "result code"
+        mock_openai.create.return_value = mock_response
+
+        llm = LocalLLM(api_base="http://localhost:11434/v1", model="codellama")
+
+        instruction = MagicMock()
+        instruction.to_string.return_value = "some prompt"
+
+        result = llm.call(instruction)
+        assert result == "result code"
+
+    def test_call_passes_extra_params(self, mock_openai):
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = "ok"
+        mock_openai.create.return_value = mock_response
+
+        llm = LocalLLM(
+            api_base="http://localhost:11434/v1",
+            model="codellama",
+            temperature=0.5,
+        )
+        instruction = MagicMock()
+        instruction.to_string.return_value = "prompt"
+        llm.call(instruction)
+
+        _, kwargs = mock_openai.create.call_args
+        assert kwargs.get("temperature") == 0.5


### PR DESCRIPTION
Fixes #1888

## Problem

`pandasai.llm.local_llm.LocalLLM` was removed when local LLMs were refactored into a separate extension in a prior commit. The extension was never published as a standalone package, which left users with a `ModuleNotFoundError` when importing `LocalLLM` — either by following the existing documentation or upgrading from v2.

## Solution

Restores `LocalLLM` directly in `pandasai/llm/local_llm.py` so that Ollama and LM Studio users can import it without installing any additional package:

```python
from pandasai.llm.local_llm import LocalLLM

# Ollama
ollama_llm = LocalLLM(api_base="http://localhost:11434/v1", model="codellama")

# LM Studio
lm_studio_llm = LocalLLM(api_base="http://localhost:1234/v1")
```

The implementation is updated to match the v3 LLM interface (`AgentState` context, `BasePrompt`, `prepend_system_prompt`).

## Testing

- Added `tests/unit_tests/llms/test_local_llm.py` with 5 unit tests covering: `type` property, default/custom API key, `call` return value, and extra parameter forwarding.
- All 5 tests pass.